### PR TITLE
sanity checks, less hard-coded configuration

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -49,7 +49,7 @@ The DAC speed is ``384*16=6144 MHz`` (resolution ``~163 ps``) and the ADC speed 
 
 * Pulse memory length: 65536 per channel x2 (I,Q), i.e., 128k total
 * Decimated ADC buffer length: 1024 samples per component (I,Q), 2k total
-* Accumulated ADC buffer length: 16384 samples per component (I,Q), 32 k total
+* Accumulated ADC buffer length: 1024 samples per component (I,Q), 2 k total
 * tProc program memory length: 8k instructions of 64 bits, 64k Bytes total
 * tProc data memory length: 4096 samples of 32 bits, 16k Bytes total
 * tProc stack size: 256 samples of 32 bits, 1k Byte total

--- a/qick_lib/qick/averager_program.py
+++ b/qick_lib/qick/averager_program.py
@@ -118,6 +118,8 @@ class AveragerProgram(QickProgram):
         
         soc.tproc.single_write(addr= 1,data=0)   #make sure count variable is reset to 0 before starting processor
         self.stats=[]
+
+        t = tqdm(total=total_count, disable=not progress) #progress bar
         
         soc.tproc.start()
         while count<total_count:   # Keep streaming data until you get all of it
@@ -134,7 +136,9 @@ class AveragerProgram(QickProgram):
                     dq_buf[ch,last_count:last_count+length]=dq[:length]
 
                 last_count+=length
+                t.update(length)
                 self.stats.append( (time.time(), count,addr, length))
+        t.close()
                     
         #save results to class in case you want to look at it later or for analysis
         self.di_buf=di_buf

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -470,6 +470,9 @@ class AxisAvgBuffer(SocIp):
         self.dma_avg.recvchannel.transfer(buff)
         self.dma_avg.recvchannel.wait()
 
+        if self.dma_avg.recvchannel.transferred != length*8:
+            raise RuntimeError("Requested %d samples but only got %d from DMA" % (length, self.dma_avg.recvchannel.transferred//8))
+
         # Stop send data mode.
         self.avg_dr_start_reg = 0
         
@@ -540,6 +543,9 @@ class AxisAvgBuffer(SocIp):
         # DMA data.
         self.dma_buf.recvchannel.transfer(buff)
         self.dma_buf.recvchannel.wait()
+
+        if self.dma_buf.recvchannel.transferred != length*4:
+            raise RuntimeError("Requested %d samples but only got %d from DMA" % (length, self.dma_buf.recvchannel.transferred//4))
 
         # Stop send data mode.
         self.buf_dr_start_reg = 0

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -110,13 +110,6 @@ class AxisSignalGenV4(SocIp):
     bindto = ['user.org:user:axis_signal_gen_v4:1.0']
     REGISTERS = {'start_addr_reg':0, 'we_reg':1, 'rndq_reg':2}
     
-    # Generics
-    N = 12
-    NDDS = 16
-    
-    # Maximum number of samples
-    MAX_LENGTH = 2**N*NDDS
-    
     def __init__(self, description, **kwargs):
         """
         Constructor method
@@ -127,6 +120,13 @@ class AxisSignalGenV4(SocIp):
         self.start_addr_reg=0
         self.we_reg=0
         self.rndq_reg = 10
+
+        # Generics
+        self.N = int(description['parameters']['N'])
+        self.NDDS = int(description['parameters']['N_DDS'])
+
+        # Maximum number of samples
+        self.MAX_LENGTH = 2**self.N*self.NDDS
         
     # Configure this driver with links to the other drivers, and the signal gen channel number.
     def configure(self, axi_dma, axis_switch, channel):
@@ -394,26 +394,26 @@ class AxisAvgBuffer(SocIp):
                  'buf_dr_addr_reg'  : 10,
                  'buf_dr_len_reg'   : 11}
     
-    # Generics
-    B = 16
-    N_AVG = 10
-    N_BUF = 10
-        
-    # Maximum number of samples
-    AVG_MAX_LENGTH = 2**N_AVG  
-    BUF_MAX_LENGTH = 2**N_BUF
-    
-    def __init__(self, ip, **kwargs):
+    def __init__(self, description, **kwargs):
         """
         Constructor method
         """
-        super().__init__(ip)
+        super().__init__(description)
         
         # Default registers.
         self.avg_start_reg    = 0
         self.avg_dr_start_reg = 0
         self.buf_start_reg    = 0
         self.buf_dr_start_reg = 0        
+
+        # Generics
+        self.B = int(description['parameters']['B'])
+        self.N_AVG = int(description['parameters']['N_AVG'])
+        self.N_BUF = int(description['parameters']['N_BUF'])
+
+        # Maximum number of samples
+        self.AVG_MAX_LENGTH = 2**self.N_AVG  
+        self.BUF_MAX_LENGTH = 2**self.N_BUF
         
     # Configure this driver with links to the other drivers, and the readout channel number.
     def configure(self, axi_dma_avg, switch_avg, axi_dma_buf, switch_buf, channel):
@@ -641,10 +641,6 @@ class AxisTProc64x32_x8(SocIp):
                  'mem_addr_reg' : 4, 
                  'mem_len_reg' : 5}
     
-    # Generics.
-    DMEM_N = 10
-    PMEM_N = 16
-    
     # Reserved lower memory section for register access.
     DMEM_OFFSET = 256 
     
@@ -667,6 +663,10 @@ class AxisTProc64x32_x8(SocIp):
         self.mem_start_reg = 0
         self.mem_addr_reg  = 0
         self.mem_len_reg   = 100
+
+        # Generics.
+        self.DMEM_N = int(description['parameters']['DMEM_N'])
+        self.PMEM_N = int(description['parameters']['PMEM_N'])
         
     # Configure this driver with links to its memory and DMA.
     def configure(self, mem, axi_dma):
@@ -865,20 +865,15 @@ class AxisSwitch(SocIp):
     bindto = ['xilinx.com:ip:axis_switch:1.1']
     REGISTERS = {'ctrl': 0x0, 'mix_mux': 0x040}
     
-    # Number of slave interfaces.
-    NSL = 1
-    
-    # Number of master interfaces.
-    NMI = 4
-    
     def __init__(self, description, **kwargs):
         """
         Constructor method
         """
         super().__init__(description)
         
-        # Set number of Slave/Master interfaces.
+        # Number of slave interfaces.
         self.NSL = int(description['parameters']['NUM_SI'])
+        # Number of master interfaces.
         self.NMI = int(description['parameters']['NUM_MI'])
         
         # Init axis_switch.
@@ -935,22 +930,24 @@ class QickSoc(Overlay):
     :type ignore_version: bool
     """
     FREF_PLL = 204.8 # MHz
-    fs_adc = 384*8 # MHz
-    fs_dac = 384*16 # MHz
-    pulse_mem_len_IQ = 65536 # samples for I, Q
-    ADC_decim_buf_len_IQ = 1024 # samples for I, Q
-    ADC_accum_buf_len_IQ = 16384 # samples for I, Q
-    tProc_instruction_len_bytes = 8 
-    tProc_prog_mem_samples = 8000
-    tProc_prog_mem_size_bytes_tot = tProc_instruction_len_bytes*tProc_prog_mem_samples
-    tProc_data_len_bytes = 4 
-    tProc_data_mem_samples = 4096
-    tProc_data_mem_size_bytes_tot = tProc_data_len_bytes*tProc_data_mem_samples
-    tProc_stack_len_bytes = 4
-    tProc_stack_samples = 256
-    tProc_stack_size_bytes_tot = tProc_stack_len_bytes*tProc_stack_samples
-    phase_resolution_bits = 32
-    gain_resolution_signed_bits = 16
+
+    # The following constants are no longer used. Some of the values may not match the bitfile.
+    #fs_adc = 384*8 # MHz
+    #fs_dac = 384*16 # MHz
+    #pulse_mem_len_IQ = 65536 # samples for I, Q
+    #ADC_decim_buf_len_IQ = 1024 # samples for I, Q
+    #ADC_accum_buf_len_IQ = 16384 # samples for I, Q
+    #tProc_instruction_len_bytes = 8 
+    #tProc_prog_mem_samples = 8000
+    #tProc_prog_mem_size_bytes_tot = tProc_instruction_len_bytes*tProc_prog_mem_samples
+    #tProc_data_len_bytes = 4 
+    #tProc_data_mem_samples = 4096
+    #tProc_data_mem_size_bytes_tot = tProc_data_len_bytes*tProc_data_mem_samples
+    #tProc_stack_len_bytes = 4
+    #tProc_stack_samples = 256
+    #tProc_stack_size_bytes_tot = tProc_stack_len_bytes*tProc_stack_samples
+    #phase_resolution_bits = 32
+    #gain_resolution_signed_bits = 16
     
     # Constructor.
     def __init__(self, bitfile=None, force_init_clks=False,ignore_version=True, **kwargs):
@@ -1023,7 +1020,7 @@ class QickSoc(Overlay):
         """
         xrfclk.set_all_ref_clks(self.__class__.FREF_PLL)
     
-    def get_decimated(self, ch, address=0, length=AxisAvgBuffer.BUF_MAX_LENGTH):
+    def get_decimated(self, ch, address=0, length=None):
         """
         Acquires data from the readout decimated buffer
 
@@ -1036,15 +1033,19 @@ class QickSoc(Overlay):
         :return: List of I and Q decimated arrays
         :rtype: list
         """
+        if length is None:
+            # this default will always cause a RuntimeError
+            # TODO: remove the default, or pick a better fallback value
+            length = self.avg_bufs[ch].BUF_MAX_LENGTH
         if length %2 != 0:
             raise RuntimeError("Buffer transfer length must be even number.")
-        if length >= AxisAvgBuffer.BUF_MAX_LENGTH:
-            raise RuntimeError("length=%d longer or euqal to %d"%(length, AxisAvgBuffer.BUF_MAX_LENGTH))
+        if length >= self.avg_bufs[ch].BUF_MAX_LENGTH:
+            raise RuntimeError("length=%d longer or equal to %d"%(length, self.avg_bufs[ch].BUF_MAX_LENGTH))
         buff = allocate(shape=length, dtype=np.int32)
         [di,dq]=self.avg_bufs[ch].transfer_buf(buff,address,length)
         return [np.array(di,dtype=float),np.array(dq,dtype=float)]
 
-    def get_accumulated(self, ch, address=0, length=AxisAvgBuffer.AVG_MAX_LENGTH):
+    def get_accumulated(self, ch, address=0, length=None):
         """
         Acquires data from the readout accumulated buffer
 
@@ -1058,10 +1059,14 @@ class QickSoc(Overlay):
             - di[:length] (:py:class:`list`) - list of accumulated I data
             - dq[:length] (:py:class:`list`) - list of accumulated Q data
         """
+        if length is None:
+            # this default will always cause a RuntimeError
+            # TODO: remove the default, or pick a better fallback value
+            length = self.avg_bufs[ch].AVG_MAX_LENGTH
         if length %2 != 0:
             raise RuntimeError("Buffer transfer length must be even number.")
-        if length >= AxisAvgBuffer.AVG_MAX_LENGTH:
-            raise RuntimeError("length=%d longer than %d"%(length, AxisAvgBuffer.AVG_MAX_LENGTH))
+        if length >= self.avg_bufs[ch].AVG_MAX_LENGTH:
+            raise RuntimeError("length=%d longer than %d"%(length, self.avg_bufs[ch].AVG_MAX_LENGTH))
         buff = allocate(shape=length, dtype=np.int64)
         di,dq = self.avg_bufs[ch].transfer_avg(buff,address=address,length=length)
 

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1037,7 +1037,37 @@ class QickSoc(Overlay):
         # tProcessor, 64-bit instruction, 32-bit registes, x8 channels.
         self.tproc  = self.axis_tproc64x32_x8_0
         self.tproc.configure(self.axi_bram_ctrl_0, self.axi_dma_tproc)
-        
+
+    def __repr__(self):
+        lines=[]
+        lines.append("\n\tGenerator switch: %d to %d"%(
+            self.switch_gen.NSL, self.switch_gen.NMI))
+        lines.append("\n\tAverager switch: %d to %d"%(
+            self.switch_avg.NSL, self.switch_avg.NMI))
+        lines.append("\n\tBuffer switch: %d to %d"%(
+            self.switch_buf.NSL, self.switch_buf.NMI))
+
+        lines.append("\n\t%d DAC channels:"%(len(self.dac_blocks)))
+        for iCh, (iTile,iBlock) in enumerate(self.dac_blocks):
+            lines.append("\t%d:\ttile %d, channel %d, fs=%.3f GHz"%(iCh,iTile,iBlock,
+                self.rf.dac_tiles[iTile].blocks[iBlock].BlockStatus['SamplingFreq']))
+
+        lines.append("\n\t%d ADC channels:"%(len(self.adc_blocks)))
+        for iCh, (iTile,iBlock) in enumerate(self.adc_blocks):
+            lines.append("\t%d:\ttile %d, channel %d, fs=%.3f GHz"%(iCh,iTile,iBlock,
+                self.rf.adc_tiles[iTile].blocks[iBlock].BlockStatus['SamplingFreq']))
+
+        lines.append("\n\t%d signal generators: max length %d samples"%(len(self.gens),
+            self.gens[0].MAX_LENGTH))
+
+        lines.append("\n\t%d readout blocks"%(len(self.readouts)))
+
+        lines.append("\n\t%d average+buffer blocks: max length %d samples (averages), %d (decimated buffer)"%(len(self.avg_bufs),
+            self.avg_bufs[0].AVG_MAX_LENGTH, 
+            self.avg_bufs[0].BUF_MAX_LENGTH))
+
+        return "\nQICK configuration:\n"+"\n".join(lines)
+
     def list_rf_blocks(self, rf_config):
         """
         Lists the enabled ADCs and DACs and get the sampling frequencies.

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -387,7 +387,7 @@ class AxisAvgBuffer(SocIp):
     
     # Generics
     B = 16
-    N_AVG = 14
+    N_AVG = 10
     N_BUF = 10
         
     # Maximum number of samples

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -156,6 +156,17 @@ class AxisSignalGenV4(SocIp):
             print("%s: buffer length must be %d samples or less." % (self.__class__.__name__,self.MAX_LENGTH))
             return
 
+        # Check for even transfer size.
+        if len(xin_i) %2 != 0:
+            raise RuntimeError("Buffer transfer length must be even number.")
+
+        # Check for max length.
+        if np.max(xin_i) > np.iinfo(np.int16).max or np.min(xin_i) < np.iinfo(np.int16).min:
+            raise ValueError("real part of envelope exceeds limits of int16 datatype")
+
+        if np.max(xin_q) > np.iinfo(np.int16).max or np.min(xin_q) < np.iinfo(np.int16).min:
+            raise ValueError("imaginary part of envelope exceeds limits of int16 datatype")
+
         # Route switch to channel.
         self.switch.sel(mst=self.ch)
         

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1066,6 +1066,8 @@ class QickSoc(Overlay):
             self.avg_bufs[0].AVG_MAX_LENGTH, 
             self.avg_bufs[0].BUF_MAX_LENGTH))
 
+        lines.append("\n\ttProc: %d words program memory, %d words data memory"%(2**self.tproc.PMEM_N, 2**self.tproc.DMEM_N))
+
         return "\nQICK configuration:\n"+"\n".join(lines)
 
     def list_rf_blocks(self, rf_config):


### PR DESCRIPTION
The main theme here is adding guardrails to protect against the mistakes I've made when learning how to use the QICK.

* freq2reg_adc() always returns a value that will be double the output of freq2reg() - you no longer need to pass all frequencies through adcfreq(), though still useful if you want to know the exact frequency you're getting
* sanity checks for waveform writes, to reject integer overflows and odd-size transfers
* N_AVG in qick.py did not match the actual buffer size in qick.bit; this causes DMA transfers to be silently truncated, and if an averager loop is too fast you will get zero values in the output. I added a sanity check that will raise an exception if a transfer is truncated, and more importantly the QickSoc configuration is automatically read from qick.hwh (and can be printed by printing the QickSoc object). This will hopefully make life easier when moving to the ZCU216 or just testing different firmware. Note that qick_asm.py still hard-codes the sampling frequencies and channel counts.