### PR TITLE
DMA improvements, remote proxying, misc. fixes

### DIFF
--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -6,11 +6,9 @@ from pynq import Overlay, DefaultIP, allocate
 try:
     import xrfclk
     import xrfdc
-    from pynq import Xlnk
 except:
     pass
 import numpy as np
-from pynq import Overlay
 from pynq.lib import AxiGPIO
 import time
 from .parser import *
@@ -191,7 +189,7 @@ class AxisSignalGenV4(SocIp):
         xin = xin.astype(np.int32)
         
         # Define buffer.
-        self.buff = Xlnk().cma_array(shape=(len(xin)), dtype=np.int32)
+        self.buff = allocate(shape=len(xin), dtype=np.int32)
         np.copyto(self.buff, xin)
         
         ################
@@ -720,8 +718,8 @@ class AxisTProc64x32_x8(SocIp):
         for ii,inst in enumerate(binprog):
             dec_low = inst & 0xffffffff
             dec_high = inst >> 32
-            self.mem.write(offset=8*ii,value=int(dec_low))
-            self.mem.write(offset=4*(2*ii+1),value=int(dec_high))
+            self.mem.write(8*ii, value=int(dec_low))
+            self.mem.write(4*(2*ii+1), value=int(dec_high))
         
     def load_qick_program(self, prog, debug= False):
         """
@@ -753,9 +751,9 @@ class AxisTProc64x32_x8(SocIp):
                 dec = int(line,2)
                 dec_low = dec & 0xffffffff
                 dec_high = dec >> 32
-                self.mem.write(offset=addr,value=int(dec_low))
+                self.mem.write(addr,value=int(dec_low))
                 addr = addr + 4
-                self.mem.write(offset=addr,value=int(dec_high))
+                self.mem.write(addr,value=int(dec_high))
                 addr = addr + 4                
                 
         # Asm file.
@@ -770,9 +768,9 @@ class AxisTProc64x32_x8(SocIp):
                 #print ("@" + str(addr) + ": " + str(dec))
                 dec_low = dec & 0xffffffff
                 dec_high = dec >> 32
-                self.mem.write(offset=addr,value=int(dec_low))
+                self.mem.write(addr,value=int(dec_low))
                 addr = addr + 4
-                self.mem.write(offset=addr,value=int(dec_high))
+                self.mem.write(addr,value=int(dec_high))
                 addr = addr + 4   
                 
     def single_read(self, addr):
@@ -790,7 +788,7 @@ class AxisTProc64x32_x8(SocIp):
         addr_temp = 4*addr + self.DMEM_OFFSET
             
         # Read data.
-        data = self.read(offset=addr_temp)
+        data = self.read(addr_temp)
             
         return data
     
@@ -807,7 +805,7 @@ class AxisTProc64x32_x8(SocIp):
         addr_temp = 4*addr + self.DMEM_OFFSET
             
         # Write data.
-        self.write(offset=addr_temp,value=int(data))
+        self.write(addr_temp,value=int(data))
         
     def load_dmem(self, buff_in, addr=0):
         """
@@ -827,7 +825,7 @@ class AxisTProc64x32_x8(SocIp):
         self.mem_len_reg = length
         
         # Define buffer.
-        self.buff = Xlnk().cma_array(shape=(length), dtype=np.int32)
+        self.buff = allocate(shape=length, dtype=np.int32)
         
         # Copy buffer.
         np.copyto(self.buff,buff_in)
@@ -859,7 +857,7 @@ class AxisTProc64x32_x8(SocIp):
         self.mem_len_reg = length
         
         # Define buffer.
-        buff = Xlnk().cma_array(shape=(length), dtype=np.int32)
+        buff = allocate(shape=length, dtype=np.int32)
         
         # Start operation on block.
         self.mem_start_reg = 1

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1192,7 +1192,7 @@ class QickSoc(Overlay):
         # Calculate the integer factors relating fstep_lcm to the DAC and ADC step sizes.
         self.regmult_dac = 2**(b_max-b_dac) * round((mult_lcm/self.fsmult_dac))
         self.regmult_adc = 2**(b_max-b_adc) * round((mult_lcm/self.fsmult_adc))
-        print(self.fstep_lcm, self.regmult_dac, self.regmult_adc)
+        #print(self.fstep_lcm, self.regmult_dac, self.regmult_adc)
 
     def freq2reg(self, f):
         """

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1190,8 +1190,8 @@ class QickSoc(Overlay):
         self.fstep_lcm = self.fs_proc * mult_lcm / 2**b_max
 
         # Calculate the integer factors relating fstep_lcm to the DAC and ADC step sizes.
-        self.regmult_dac = 2**(b_max-b_dac) * round((mult_lcm/self.fsmult_dac))
-        self.regmult_adc = 2**(b_max-b_adc) * round((mult_lcm/self.fsmult_adc))
+        self.regmult_dac = int(2**(b_max-b_dac) * round(mult_lcm/self.fsmult_dac))
+        self.regmult_adc = int(2**(b_max-b_adc) * round(mult_lcm/self.fsmult_adc))
         #print(self.fstep_lcm, self.regmult_dac, self.regmult_adc)
 
     def freq2reg(self, f):

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1205,7 +1205,7 @@ class QickSoc(Overlay):
         """
         #ch_info={1: (0,0), 2: (0,1), 3: (0,2), 4: (1,0), 5: (1,1), 6: (1, 2), 7: (1,3)}
     
-        tile, channel = self.dac_blocks[ch+1]
+        tile, channel = self.dac_blocks[ch-1]
         dac_block=self.rf.dac_tiles[tile].blocks[channel]
         dac_block.NyquistZone=nqz
         return dac_block.NyquistZone

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1075,6 +1075,7 @@ class QickSoc(Overlay):
             self.avg_bufs[0].BUF_MAX_LENGTH))
 
         lines.append("\n\ttProc: %d words program memory, %d words data memory"%(2**self.tproc.PMEM_N, 2**self.tproc.DMEM_N))
+        lines.append("\t\tprogram RAM: %d bytes"%(self.tproc.mem.mmio.length))
 
         return "\nQICK configuration:\n"+"\n".join(lines)
 

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -979,6 +979,8 @@ class QickSoc(Overlay):
         else:
             super().__init__(bitfile, ignore_version=ignore_version, **kwargs)
 
+        self.board = os.environ["BOARD"]
+
         # RF data converter (for configuring ADCs and DACs)
         self.rf = self.usp_rf_data_converter_0
 
@@ -1066,6 +1068,7 @@ class QickSoc(Overlay):
 
     def description(self):
         lines=[]
+        lines.append("\n\tBoard: " + self.board)
         lines.append("\n\tGlobal clocks: fabric %.3f MHz, reference %.3f MHz"%(
             self.fabric_freq, self.refclk_freq))
         lines.append("\n\tGenerator switch: %d to %d"%(
@@ -1157,13 +1160,14 @@ class QickSoc(Overlay):
         """
         Resets all the board clocks
         """
-        #for ZCU111
-        #print("resetting clocks:",self.refclk_freq)
-        #xrfclk.set_all_ref_clks(self.refclk_freq)
-
-        #for ZCU216
-        print("resetting clocks:",self.refclk_freq,self.refclk_freq*2)
-        xrfclk.set_ref_clks(lmk_freq=self.refclk_freq, lmx_freq=self.refclk_freq*2)
+        if self.board=='ZCU111':
+            print("resetting clocks:",self.refclk_freq)
+            xrfclk.set_all_ref_clks(self.refclk_freq)
+        elif self.board=='ZCU216':
+            lmk_freq = self.refclk_freq
+            lmx_freq = self.refclk_freq*2
+            print("resetting clocks:",lmk_freq, lmx_freq)
+            xrfclk.set_ref_clks(lmk_freq=lmk_freq, lmx_freq=lmx_freq)
     
     def get_decimated(self, ch, address=0, length=None):
         """

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1051,11 +1051,19 @@ class QickSoc(Overlay):
 
 
         # tProcessor, 64-bit instruction, 32-bit registes, x8 channels.
-        self.tproc  = self.axis_tproc64x32_x8_0
-        self.tproc.configure(self.axi_bram_ctrl_0, self.axi_dma_tproc)
+        self._tproc  = self.axis_tproc64x32_x8_0
+        self._tproc.configure(self.axi_bram_ctrl_0, self.axi_dma_tproc)
         #print(self.description())
 
-        self.streamer = DataStreamer(self)
+        self._streamer = DataStreamer(self)
+
+    @property
+    def tproc(self):
+        return self._tproc
+
+    @property
+    def streamer(self):
+        return self._streamer
 
     def description(self):
         lines=[]
@@ -1196,59 +1204,6 @@ class QickSoc(Overlay):
         # we remove the padding here
         return data[:,:length]
     
-    def start(self):
-        """Start the tprocessor"""
-        return self.tproc.start()
-
-    def stop(self):
-        """Stop the tprocessor"""
-        return self.tproc.stop()
-
-    def single_read(self, addr):
-        """Read single value from data memory
-        
-        :param addr: Address of data memory to read
-        :type addr: int
-        :return: value at data address 'addr' 
-        :rtype: int
-
-        """
-        return self.tproc.single_read(addr)
-
-    def single_write(self, addr,data):
-        """Read single value from data memory
-        
-        :param addr: Address of data memory to read
-        :type addr: int
-        :param data: data to write into memory
-        :type data: int
-        """
-        return self.tproc.single_write(addr,data)
-
-    def read_dmem(self, addr=0, length=100):
-        """
-        Reads tProc data memory using DMA
-
-        :param addr: Starting address
-        :type addr: int
-        :param length: Number of samples
-        :type length: int
-        :return: List of memory data
-        :rtype: list
-        """
-        return self.tproc.read_dmem(addr,length)
-
-    def load_dmem(self, buff_in, addr=0):
-        """
-        Writes tProc data memory using DMA
-
-        :param buff_in: Input buffer
-        :type buff_in: int
-        :param addr: Starting destination address
-        :type addr: int
-        """
-        return self.tproc.load_dmem(buff_in, addr)
-
     def configure_readout(self, ch, output, frequency):
         """Configure readout channel output style and frequency
         :param ch: Channel to configure
@@ -1295,9 +1250,6 @@ class QickSoc(Overlay):
     def enable_buf(self, ch):
         self.avg_bufs[ch].enable_buf()
         
-    def load_bin_program(self, binprog):
-        return self.tproc.load_bin_program(binprog)
-
     def get_avg_max_length(self, ch=0):
         """Get accumulation buffer length for channel
         :param ch: Channel
@@ -1350,17 +1302,3 @@ class QickSoc(Overlay):
         dac_block.NyquistZone=nqz
         return dac_block.NyquistZone
 
-    def start_readout(self, total_count, counter_addr=1, ch_list=[0,1]):
-        return self.streamer.start_readout(total_count, counter_addr, ch_list)
-
-    def stop_readout(self):
-        return self.streamer.stop_readout()
-
-    def readout_done(self):
-        return self.streamer.readout_done()
-
-    def readout_alive(self):
-        return self.streamer.readout_alive()
-
-    def poll_data(self):
-        return self.streamer.poll_data()

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -14,6 +14,7 @@ from pynq import Overlay
 from pynq.lib import AxiGPIO
 import time
 from .parser import *
+from .streamer import DataStreamer
 from . import bitfile_path
 
 # Some support functions
@@ -1054,8 +1055,11 @@ class QickSoc(Overlay):
         # tProcessor, 64-bit instruction, 32-bit registes, x8 channels.
         self.tproc  = self.axis_tproc64x32_x8_0
         self.tproc.configure(self.axi_bram_ctrl_0, self.axi_dma_tproc)
+        #print(self.description())
 
-    def __repr__(self):
+        self.streamer = DataStreamer(self)
+
+    def description(self):
         lines=[]
         lines.append("\n\tGenerator switch: %d to %d"%(
             self.switch_gen.NSL, self.switch_gen.NMI))
@@ -1087,6 +1091,9 @@ class QickSoc(Overlay):
         lines.append("\t\tprogram RAM: %d bytes"%(self.tproc.mem.mmio.length))
 
         return "\nQICK configuration:\n"+"\n".join(lines)
+
+    def __repr__(self):
+        return self.description()
 
     def list_rf_blocks(self, rf_config):
         """
@@ -1345,3 +1352,17 @@ class QickSoc(Overlay):
         dac_block.NyquistZone=nqz
         return dac_block.NyquistZone
 
+    def start_readout(self, total_count, counter_addr=1, ch_list=[0,1]):
+        return self.streamer.start_readout(total_count, counter_addr, ch_list)
+
+    def stop_readout(self):
+        return self.streamer.stop_readout()
+
+    def readout_done(self):
+        return self.streamer.readout_done()
+
+    def readout_alive(self):
+        return self.streamer.readout_alive()
+
+    def poll_data(self):
+        return self.streamer.poll_data()

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -17,6 +17,7 @@ def freq2reg(f):
     :return: Re-formatted frequency
     :rtype: int
     """
+    raise DeprecationWarning("freq2reg() is deprecated! Use QickSoc.freq2reg() instead.")
     B=32
     df = 2**B/fs_dac
     f_i = f*df
@@ -32,6 +33,7 @@ def freq2reg_adc(f):
     :return: Re-formatted frequency
     :rtype: int
     """
+    raise DeprecationWarning("freq2reg_adc() is deprecated! Use QickSoc.configure_readout() instead.")
     B=32
     df = 2**B/fs_adc
     f_i = f*df
@@ -46,6 +48,7 @@ def reg2freq(r):
     :return: Re-formatted frequency in MHz
     :rtype: float
     """
+    raise DeprecationWarning("reg2freq() is deprecated! Use QickSoc.reg2freq() instead.")
     return r*fs_dac/2**32
 
 def reg2freq_adc(r):
@@ -57,6 +60,7 @@ def reg2freq_adc(r):
     :return: Re-formatted frequency in MHz
     :rtype: float
     """
+    raise DeprecationWarning("reg2freq_adc() is deprecated! Use QickSoc.reg2freq_adc() instead.")
     return r*fs_adc/2**32
 
 def adcfreq(f):
@@ -68,6 +72,7 @@ def adcfreq(f):
     :return: Re-formatted frequency
     :rtype: int
     """
+    raise DeprecationWarning("adcfreq() is deprecated! It is no longer needed when setting registers; otherwise, Use QickSoc.adcfreq() instead.")
     reg=freq2reg_adc(f)
     return reg2freq_adc(reg)
 
@@ -80,6 +85,7 @@ def cycles2us(cycles):
     :return: Number of microseconds
     :rtype: float
     """
+    raise DeprecationWarning("cycles2us() is deprecated! Use QickSoc.cycles2us() instead.")
     return cycles/fs_proc
 
 def us2cycles(us):
@@ -91,6 +97,7 @@ def us2cycles(us):
     :return: Number of tProc clock cycles
     :rtype: int
     """
+    raise DeprecationWarning("us2cycles() is deprecated! Use QickSoc.us2cycles() instead.")
     return int(us*fs_proc)
 
 def deg2reg(deg):
@@ -291,7 +298,9 @@ class QickProgram:
         p=self
         rp=self.ch_page(ch)
         r_freq,r_phase,r_addr, r_gain, r_mode, r_t = p.sreg(ch,'freq'), p.sreg(ch,'phase'), p.sreg(ch,'addr'), p.sreg(ch,'gain'), p.sreg(ch,'mode'), p.sreg(ch,'t')
-        if freq is not None: p.safe_regwi (rp, r_freq, freq, f'freq = {reg2freq(freq)} MHz')
+        #TODO: if we can do compile-time conversion for frequency, we can bring this print back
+        #if freq is not None: p.safe_regwi (rp, r_freq, freq, f'freq = {reg2freq(freq)} MHz')
+        if freq is not None: p.safe_regwi (rp, r_freq, freq, f'freq = {freq}')
         if phase is not None: p.safe_regwi (rp, r_phase, phase, f'phase = {phase}')
         if gain is not None: p.regwi (rp, r_gain, gain, f'gain = {gain}')
         if t is not None and t !='auto': p.regwi (rp, r_t, t, f't = {t}')

--- a/qick_lib/qick/streamer.py
+++ b/qick_lib/qick/streamer.py
@@ -108,16 +108,16 @@ class DataStreamer():
         stride=int(0.5 * self.soc.get_avg_max_length(0)) # how many measurements to transfer at a time
         # bigger stride is more efficient, but the transfer size must never exceed AVG_MAX_LENGTH, so the stride should be set with some safety margin
 
-        self.soc.stop()
+        self.soc.tproc.stop()
 
-        self.soc.single_write(addr= counter_addr,data=0)   #make sure count variable is reset to 0 before starting processor
+        self.soc.tproc.single_write(addr= counter_addr,data=0)   #make sure count variable is reset to 0 before starting processor
         stats=[]
 
         t_start = time.time()
 
-        self.soc.start()
+        self.soc.tproc.start()
         while (not self.stop_flag.is_set()) and count<total_count:   # Keep streaming data until you get all of it
-            count = self.soc.single_read(addr= counter_addr)
+            count = self.soc.tproc.single_read(addr= counter_addr)
             if count>=min(last_count+stride,total_count-1):  #wait until either you've gotten a full stride of measurements or you've finished (so you don't go crazy trying to download every measurement)
                 addr=last_count % self.soc.get_avg_max_length(0)
                 length = count-last_count

--- a/qick_lib/qick/streamer.py
+++ b/qick_lib/qick/streamer.py
@@ -1,0 +1,146 @@
+import numpy as np
+from multiprocessing import Process, Queue, Event
+import queue
+import time
+import os
+
+class DataStreamer():
+    """
+    Uses a separate process to read data from the average buffers.
+
+    We don't lock the QickSoc or the IPs. The user is responsible for not disrupting a readout in progress.
+
+    :param soc: The QickSoc object.
+    :type soc: QickSoc
+    """
+    def __init__(self, soc):
+        self.soc = soc
+
+        # Process object for the streaming readout.
+        self.readout_process=None
+
+        # Passes data from the worker process to the main process.
+        self.data_queue = Queue()
+        # The main process can use this flag to tell the worker process to stop.
+        self.stop_flag = Event()
+        # The worker process uses this to tell the main process when it's done.
+        self.done_flag = Event()
+
+    def start_readout(self,total_count, counter_addr=1, ch_list=[0,1]):
+        """
+        Start a streaming readout of the average buffers.
+
+        :param total_count: Number of data points expected
+        :type addr: int
+        :param counter_addr: Data memory address for the loop counter
+        :type counter_addr: int
+        :param ch_list: List of readout channels
+        :type addr: list
+        """
+
+        if self.readout_alive():
+            raise RuntimeError("Cannot start a readout when the readout is still alive.")
+
+        # Initialize flags.
+        self.stop_flag.clear()
+        self.done_flag.clear()
+
+        # daemon=True means the readout process will be killed if the parent is killed
+        self.readout_process = Process(target=self._run_readout, args=(total_count, counter_addr, ch_list), daemon=True)
+        self.readout_process.start()
+
+    def stop_readout(self):
+        """
+        Signal the readout loop to break.
+        The readout process will stay alive until you have read any data already in the data queue.
+        """
+        self.stop_flag.set()
+
+    def readout_done(self):
+        """
+        Test if the readout loop is running.
+        There may still be unread data in the queue.
+
+        :return: readout loop flag
+        :rtype: bool
+        """
+        return self.done_flag.is_set()
+
+    def readout_alive(self):
+        """
+        Test if the readout process is still alive.
+        This is true as long as the readout loop is running, or there is unread data in the queue.
+        You will not be able to start a new readout until this is false.
+
+        :return: readout process status
+        :rtype: bool
+        """
+        return self.readout_process is not None and self.readout_process.is_alive()
+
+    def poll_data(self):
+        """
+        Get as much data as possible from the data queue.
+
+        :return: list of (data, stats) pairs, oldest first
+        :rtype: list
+        """
+        new_data = []
+        while True:
+            try:
+                new_data.append(self.data_queue.get(timeout=0.001))
+            except queue.Empty:
+                break
+        return new_data
+
+    def _run_readout(self, total_count, counter_addr, ch_list):
+        """
+        Worker process for the streaming readout
+
+        :param total_count: Number of data points expected
+        :type addr: int
+        :param counter_addr: Data memory address for the loop counter
+        :type counter_addr: int
+        :param ch_list: List of readout channels
+        :type addr: list
+        """
+        count=0
+        last_count=0
+        stride=int(0.5 * self.soc.get_avg_max_length(0)) # how many measurements to transfer at a time
+        # bigger stride is more efficient, but the transfer size must never exceed AVG_MAX_LENGTH, so the stride should be set with some safety margin
+
+        self.soc.stop()
+
+        self.soc.single_write(addr= counter_addr,data=0)   #make sure count variable is reset to 0 before starting processor
+        stats=[]
+
+        t_start = time.time()
+
+        self.soc.start()
+        while (not self.stop_flag.is_set()) and count<total_count:   # Keep streaming data until you get all of it
+            count = self.soc.single_read(addr= counter_addr)
+            if count>=min(last_count+stride,total_count-1):  #wait until either you've gotten a full stride of measurements or you've finished (so you don't go crazy trying to download every measurement)
+                addr=last_count % self.soc.get_avg_max_length(0)
+                length = count-last_count
+                length -= length%2 # transfers must be of even length; trim the length (instead of padding it)
+                if length>=self.soc.get_avg_max_length(0):
+                    raise RuntimeError("Overflowed the averages buffer (%d unread samples >= buffer size %d)."
+                            %(length, self.soc.get_avg_max_length(0)) +
+                            "\nYou need to slow down the tProc by increasing relax_delay." +
+                            "\nIf the TQDM progress bar is enabled, disabling it may help.")
+
+                # buffer for each channel
+                d_buf=np.zeros((len(ch_list),2,length))
+
+                for iCh, ch in enumerate(ch_list):  #for each adc channel get the single shot data and add it to the buffer
+                    data = self.soc.get_accumulated(ch=ch,address=addr, length=length)
+
+                    d_buf[iCh]=data
+
+                last_count+=length
+
+                stats = (time.time()-t_start, count,addr, length)
+                self.data_queue.put((d_buf, stats))
+        self.done_flag.set()
+
+        # Note that the process will not terminate until the queue is empty.
+


### PR DESCRIPTION
* allocate DMA buffers once at initialization, instead of having to get a new continuous memory block for each transfer
* speed up acquire_decimated by using ndarrays instead of iterating over multiple arrays
* merge in Dave's changes, which allow the QickSoc to be proxied over Pyro4
* DataStreamer class handles starting and controlling a separate process for streaming readout of the average buffer (important for decoupling network latency from the readout loop when proxying) - so far only implemented in AveragerProgram

fix some issues from PR #2, flagged by Dave:
* bug in set_nyquist()
* the new progress bar in acquire_round() is often too much clutter - we have decided that acquire() and acquire_round() should just default to progress=False, and users should be explicit when they want to see the progress bar

fix some compatibility issues Ken found with pynq v2.7:
* Xlnk was deprecated in favor of allocate
* mem.write() doesn't like the "offset" keyword

changes to support ZCU216:
* detect which board you're running, and do the appropriate thing for setting up the clock references
* no more hard-coded sampling frequencies; all frequency<->register math now happens in QickSoc, all qick_asm functions now have DeprecationWarnings (demo notebooks have not been updated to match)