### PR TITLE
get channel mapping from HWH parser

### DIFF
--- a/qick_lib/qick/helpers.py
+++ b/qick_lib/qick/helpers.py
@@ -39,3 +39,46 @@ def triang(length=100,maxv=30000):
     y = np.concatenate((y1,y2))
     y = y/np.max(y)*maxv
     return y
+
+def trace_net(parser, blockname, portname):
+    """
+    Find the block and port that connect to this block and port.
+    If you expect to only get one block+port as a result, you can assign the result to ((block, port),)
+
+    :param parser: HWH parser object (from Overlay.parser, or BusParser)
+    :param blockname: the IP block of interest
+    :type blockname: string
+    :param portname: the port we want to trace
+    :type portname: string
+
+    :return: a list of (block, port) pairs
+    :rtype: list
+    """
+
+    fullport = blockname+"/"+portname
+    # the net connected to this port
+    netname = parser.pins[fullport]
+    # get the list of other ports on this net, discard the port we started at and ILA ports
+    return [x.split('/') for x in parser.nets[netname] if x!=fullport and 'system_ila_' not in x]
+
+class BusParser:
+    def __init__(self, parser):
+        """
+        Matching all the buses in the modules from the HWH file.
+        This is essentially a copy of the HWH parser's match_nets() and match_pins(),
+        but working on buses instead of signals.
+
+        :param parser: HWH parser object (from Overlay.parser)
+        """
+        self.nets = {}
+        self.pins = {}
+        for module in parser.root.findall('./MODULES/MODULE'):
+            fullpath = module.get('FULLNAME').lstrip('/')
+            for bus in module.findall('./BUSINTERFACES/BUSINTERFACE'):
+                port = fullpath + '/' + bus.get('NAME')
+                busname = bus.get('BUSNAME')
+                self.pins[port] = busname
+                if busname in self.nets:
+                    self.nets[busname] |= set([port])
+                else:
+                    self.nets[busname] = set([port])

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -14,6 +14,7 @@ import time
 from .parser import *
 from .streamer import DataStreamer
 from .qick_asm import QickConfig
+from .helpers import trace_net, BusParser
 from . import bitfile_path
 
 # Some support functions
@@ -132,9 +133,9 @@ class AxisSignalGenV4(SocIp):
         # Maximum number of samples
         self.MAX_LENGTH = 2**self.N*self.NDDS
 
-        # Get the channel number from the IP instance name.
-        self.ch = int(self.fullpath.split('_')[-1])
-        
+        # Frequency resolution
+        self.B_DDS = 32
+
     # Configure this driver with links to the other drivers, and the signal gen channel number.
     def configure(self, axi_dma, axis_switch):
         # dma
@@ -143,8 +144,28 @@ class AxisSignalGenV4(SocIp):
         # Switch
         self.switch = axis_switch
         
-    def configure_connections(self, parser):
-        pass
+    def configure_connections(self, soc, sigparser, busparser):
+        # what tProc output port drives this generator?
+        # we will eventually also use this to find out which tProc drives this gen, for multi-tProc firmwares
+        ((block,port),) = trace_net(busparser, self.fullpath, 's1_axis')
+        # might need to jump through an axis_clk_cnvrt
+        if 'axis_tproc' not in block:
+            ((block,port),) = trace_net(busparser, block, 'S_AXIS')
+        # port names are of the form 'm2_axis_tdata'
+        # subtract 1 to get the output channel number (m0 goes to the DMA)
+        self.tproc_ch = int(port.split('_')[0][1:])-1
+
+        # what switch port drives this generator?
+        ((block,port),) = trace_net(busparser, self.fullpath, 's0_axis')
+        # port names are of the form 'M01_AXIS'
+        self.switch_ch = int(port.split('_')[0][1:])
+
+        # what RFDC port does this generator drive?
+        ((block,port),) = trace_net(busparser, self.fullpath, 'm_axis')
+        # port names are of the form 's00_axis'
+        self.dac = port[1:3]
+
+        #print("%s: switch %d, tProc ch %d, DAC tile %s block %s"%(self.fullpath, self.switch_ch, self.tproc_ch, *self.dac))
 
     # Load waveforms.
     def load(self, xin_i, xin_q ,addr=0):
@@ -180,7 +201,7 @@ class AxisSignalGenV4(SocIp):
             raise ValueError("imaginary part of envelope exceeds limits of int16 datatype")
 
         # Route switch to channel.
-        self.switch.sel(mst=self.ch)
+        self.switch.sel(mst=self.switch_ch)
         
         #time.sleep(0.050)
         
@@ -278,9 +299,6 @@ class AxisReadoutV2(SocIp):
         # Register update.
         self.update()
         
-        # Get the channel number from the IP instance name.
-        self.ch = int(description['fullpath'].split('_')[-1])
-
     # Configure this driver with the sampling frequency.
     def configure(self, fstep, regmult):
         # Frequency step for rounding.
@@ -290,6 +308,22 @@ class AxisReadoutV2(SocIp):
         # Sampling frequency.
         self.fs = 2**self.B_DDS * fstep/regmult
         
+    def configure_connections(self, soc, sigparser, busparser):
+        # what RFDC port drives this readout?
+        ((block,port),) = trace_net(busparser, self.fullpath, 's_axis')
+        # jump through an axis_register_slice
+        ((block,port),) = trace_net(busparser, block, 'S_AXIS')
+        # port names are of the form 'm02_axis' where the block number is always even
+        iTile, iBlock = [int(x) for x in port[1:3]]
+        iBlock //= 2
+        self.adc = "%d%d"%(iTile, iBlock)
+
+        # what buffer does this readout drive?
+        ((block,port),) = trace_net(busparser, self.fullpath, 'm1_axis')
+        self.buffer = getattr(soc, block)
+
+        #print("%s: ADC tile %s block %s, buffer %s"%(self.fullpath, *self.adc, self.buffer.fullpath))
+
     def update(self):
         """
         Update register values
@@ -433,9 +467,6 @@ class AxisAvgBuffer(SocIp):
         self.avg_buff = allocate(shape=self.AVG_MAX_LENGTH, dtype=np.int64)
         self.buf_buff = allocate(shape=self.BUF_MAX_LENGTH, dtype=np.int32)
 
-        # Get the channel number from the IP instance name.
-        self.ch = int(description['fullpath'].split('_')[-1])
-
     # Configure this driver with links to the other drivers.
     def configure(self, axi_dma_avg, switch_avg, axi_dma_buf, switch_buf):
         # DMAs.
@@ -446,6 +477,39 @@ class AxisAvgBuffer(SocIp):
         self.switch_avg = switch_avg
         self.switch_buf = switch_buf
         
+    def configure_connections(self, soc, sigparser, busparser):
+        # which readout drives this buffer?
+        ((block,port),) = trace_net(busparser, self.fullpath, 's_axis')
+        self.readout = getattr(soc, block)
+
+        # which switch_avg port does this buffer drive?
+        ((block,port),) = trace_net(busparser, self.fullpath, 'm0_axis')
+        # port names are of the form 'S01_AXIS'
+        switch_avg_ch = int(port.split('_')[0][1:],10)
+
+        # which switch_buf port does this buffer drive?
+        ((block,port),) = trace_net(busparser, self.fullpath, 'm1_axis')
+        # port names are of the form 'S01_AXIS'
+        switch_buf_ch = int(port.split('_')[0][1:],10)
+        if switch_avg_ch!=switch_buf_ch:
+            raise RuntimeError("switch_avg and switch_buf port numbers do not match:",self.fullpath)
+        self.switch_ch = switch_avg_ch
+
+        # which tProc output bit triggers this buffer?
+        ((block,port),) = trace_net(sigparser, self.fullpath, 'trigger')
+        # port names are of the form 'dout14'
+        self.trigger_bit = int(port[4:])
+
+        # which tProc input port does this buffer drive?
+        ((block,port),) = trace_net(busparser, self.fullpath, 'm2_axis')
+        # jump through an axis_clk_cnvrt
+        ((block,port),) = trace_net(busparser, block, 'M_AXIS')
+        # port names are of the form 's1_axis'
+        # subtract 1 to get the channel number (s0 comes from the DMA)
+        self.tproc_ch = int(port.split('_')[0][1:])-1
+
+        #print("%s: readout %s, switch %d, trigger %d, tProc port %d"%(self.fullpath, self.readout.fullpath, self.switch_ch, self.trigger_bit, self.tproc_ch))
+
 
     def config(self,address=0,length=100):
         """
@@ -502,7 +566,7 @@ class AxisAvgBuffer(SocIp):
             raise RuntimeError("length=%d longer than %d"%(length, self.AVG_MAX_LENGTH))
 
         # Route switch to channel.
-        self.switch_avg.sel(slv=self.ch)        
+        self.switch_avg.sel(slv=self.switch_ch)
         
         # Set averager data reader address and length.
         self.avg_dr_addr_reg = address
@@ -577,7 +641,7 @@ class AxisAvgBuffer(SocIp):
             raise RuntimeError("length=%d longer or equal to %d"%(length, self.BUF_MAX_LENGTH))
 
         # Route switch to channel.
-        self.switch_buf.sel(slv=self.ch)
+        self.switch_buf.sel(slv=self.switch_ch)
         
         #time.sleep(0.050)
         
@@ -1023,46 +1087,69 @@ class QickSoc(Overlay, QickConfig):
         # Signal generators.
         self.gens = []
 
-        # Readout blocks.
-        self.readouts = []
-
         # Average + Buffer blocks.
         self.avg_bufs = []
 
+        # Use the HWH parser to trace connectivity and deduce the channel numbering.
+        # Since the HWH parser doesn't parse buses, we also make our own BusParser.
+        busparser = BusParser(self.parser)
         for key,val in self.ip_dict.items():
             if hasattr(val['driver'],'configure_connections'):
-                getattr(self,key).configure_connections(self.parser)
+                getattr(self,key).configure_connections(self, self.parser, busparser)
+
         # Populate the lists with the registered IP blocks.
         for key,val in self.ip_dict.items():
             if (val['driver'] == AxisSignalGenV4):
                 self.gens.append(getattr(self,key))
-            elif (val['driver'] == AxisReadoutV2):
-                self.readouts.append(getattr(self,key))
             elif (val['driver'] == AxisAvgBuffer):
                 self.avg_bufs.append(getattr(self,key))
 
-        # Sanity check: we should have the same number of signal generators as DACs.
-        if len(self.dac_blocks) != len(self.gens):
-            raise RuntimeError("We have %d DACs but %d signal generators."%(len(self.dac_blocks),len(self.gens)))
+        # Sanity check: we should have the same number of signal generators as switch ports.
+        if self.switch_gen.NMI != len(self.gens):
+            raise RuntimeError("We have %d switch_gen outputs but %d signal generators."%(len(self.switch_gen.NMI),len(self.gens)))
 
-        # Sanity check: we should have the same number of readouts and buffer blocks as ADCs.
-        if len(self.adc_blocks) != len(self.readouts):
-            raise RuntimeError("We have %d ADCs but %d readout blocks."%(len(self.adc_blocks),len(self.readouts)))
-        if len(self.adc_blocks) != len(self.avg_bufs):
-            raise RuntimeError("We have %d ADCs but %d avg/buffer blocks."%(len(self.adc_blocks),len(self.avg_bufs)))
-        
+        # Sanity check: we should have the same number of readouts and buffer blocks as switch ports.
+        if self.switch_avg.NSL != len(self.avg_bufs):
+            raise RuntimeError("We have %d switch_avg inputs but %d avg/buffer blocks."%(len(self.switch_avg.NSL),len(self.avg_bufs)))
+        if self.switch_buf.NSL != len(self.avg_bufs):
+            raise RuntimeError("We have %d switch_buf inputs but %d avg/buffer blocks."%(len(self.switch_buf.NSL),len(self.avg_bufs)))
+
         # Sort the lists by channel number.
         # Typically they are already in order, but good to make sure?
-        self.gens.sort(key=lambda x: x.ch)
-        self.readouts.sort(key=lambda x: x.ch)
-        self.avg_bufs.sort(key=lambda x: x.ch)
+        # The single source of truth for channel numbering is the switch port index.
+        self.gens.sort(key=lambda x: x.switch_ch)
+        self.avg_bufs.sort(key=lambda x: x.switch_ch)
+
+        # Readout blocks.
+        self.readouts = [buf.readout for buf in self.avg_bufs]
 
         # Fill the config dictionary with driver parameters.
-        self.cfg['b_dac'] = 32
+        self.cfg['b_dac'] = self.gens[0].B_DDS #typically 32
         self.cfg['b_adc'] = self.readouts[0].B_DDS #typically 32
-        self.cfg['avg_bufs'] = [{'avg_maxlen':buf.AVG_MAX_LENGTH,
-                                 'buf_maxlen':buf.BUF_MAX_LENGTH} 
-                                 for buf in self.avg_bufs]
+
+        self.cfg['gens'] = []
+        self.cfg['readouts'] = []
+        for iGen,gen in enumerate(self.gens):
+            thiscfg = {}
+            thiscfg['maxlen'] = gen.MAX_LENGTH
+            thiscfg['b_dds'] = gen.B_DDS
+            thiscfg['tproc_ch'] = gen.tproc_ch
+            thiscfg['dac'] = gen.dac
+            thiscfg['fs'] = self.dacs[gen.dac]['fs']
+            thiscfg['f_fabric'] = self.dacs[gen.dac]['f_fabric']
+            self.cfg['gens'].append(thiscfg)
+
+        for iBuf,buf in enumerate(self.avg_bufs):
+            thiscfg = {}
+            thiscfg['avg_maxlen'] = buf.AVG_MAX_LENGTH
+            thiscfg['buf_maxlen'] = buf.BUF_MAX_LENGTH
+            thiscfg['b_dds'] = buf.readout.B_DDS
+            thiscfg['adc'] = buf.readout.adc
+            thiscfg['fs'] = self.adcs[buf.readout.adc]['fs']
+            thiscfg['f_fabric'] = self.adcs[buf.readout.adc]['f_fabric']
+            thiscfg['trigger_bit'] = buf.trigger_bit
+            thiscfg['tproc_ch'] = buf.tproc_ch
+            self.cfg['readouts'].append(thiscfg)
 
         # tProcessor, 64-bit instruction, 32-bit registers, x8 channels.
         self._tproc  = self.axis_tproc64x32_x8_0
@@ -1116,31 +1203,36 @@ class QickSoc(Overlay, QickConfig):
         hs_adc = rf_config['C_High_Speed_ADC']=='1'
 
         self.dac_tiles = []
-        self.dac_blocks = []
         self.adc_tiles = []
-        self.adc_blocks = []
         dac_fabric_freqs = []
         adc_fabric_freqs = []
         refclk_freqs = []
+        self.dacs = {}
+        self.adcs = {}
 
         for iTile in range(4):
             if rf_config['C_DAC%d_Enable'%(iTile)]!='1':
                 continue
             self.dac_tiles.append(iTile)
-            dac_fabric_freqs.append(float(rf_config['C_DAC%d_Fabric_Freq'%(iTile)]))
-            refclk_freqs.append(float(rf_config['C_DAC%d_Refclk_Freq'%(iTile)]))
+            f_fabric = float(rf_config['C_DAC%d_Fabric_Freq'%(iTile)])
+            f_refclk = float(rf_config['C_DAC%d_Refclk_Freq'%(iTile)])
+            dac_fabric_freqs.append(f_fabric)
+            refclk_freqs.append(f_refclk)
             fs = float(rf_config['C_DAC%d_Sampling_Rate'%(iTile)])*1000
             for iBlock in range(4):
                 if rf_config['C_DAC_Slice%d%d_Enable'%(iTile,iBlock)]!='true':
                     continue
-                self.dac_blocks.append((iTile,iBlock,fs))
+                self.dacs["%d%d"%(iTile,iBlock)] = {'fs':fs,
+                                                    'f_fabric':f_fabric}
 
         for iTile in range(4):
             if rf_config['C_ADC%d_Enable'%(iTile)]!='1':
                 continue
             self.adc_tiles.append(iTile)
-            adc_fabric_freqs.append(float(rf_config['C_ADC%d_Fabric_Freq'%(iTile)]))
-            refclk_freqs.append(float(rf_config['C_ADC%d_Refclk_Freq'%(iTile)]))
+            f_fabric = float(rf_config['C_ADC%d_Fabric_Freq'%(iTile)])
+            f_refclk = float(rf_config['C_ADC%d_Refclk_Freq'%(iTile)])
+            adc_fabric_freqs.append(f_fabric)
+            refclk_freqs.append(f_refclk)
             fs = float(rf_config['C_ADC%d_Sampling_Rate'%(iTile)])*1000
             #for iBlock,block in enumerate(tile.blocks):
             for iBlock in range(4):
@@ -1150,18 +1242,21 @@ class QickSoc(Overlay, QickConfig):
                 else:
                     if rf_config['C_ADC_Slice%d%d_Enable'%(iTile,iBlock)]!='true':
                         continue
-                self.adc_blocks.append((iTile,iBlock,fs))
+                self.adcs["%d%d"%(iTile,iBlock)] = {'fs':fs,
+                                                    'f_fabric':f_fabric}
 
         def get_common_freq(freqs):
             """
             Check that all elements of the list are equal, and return the common value.
             """
+            if not freqs: # input is empty list
+                return None
             if len(set(freqs))!=1:
                 raise RuntimeError("Unexpected frequencies:",freqs)
             return freqs[0]
 
-        self.cfg['fs_dac'] = get_common_freq([block[2] for block in self.dac_blocks])
-        self.cfg['fs_adc'] = get_common_freq([block[2] for block in self.adc_blocks])
+        self.cfg['fs_dac'] = get_common_freq([block[1]['fs'] for block in self.dacs.items()])
+        self.cfg['fs_adc'] = get_common_freq([block[1]['fs'] for block in self.adcs.items()])
 
         # Assume the tProc has the same frequency as the DAC fabric.
         self.cfg['fs_proc'] = get_common_freq(dac_fabric_freqs)
@@ -1327,7 +1422,7 @@ class QickSoc(Overlay, QickConfig):
         """
         #ch_info={1: (0,0), 2: (0,1), 3: (0,2), 4: (1,0), 5: (1,1), 6: (1, 2), 7: (1,3)}
     
-        tile, channel, _ = self.dac_blocks[ch-1]
+        tile, channel = [int(a) for a in self.cfg['gens'][ch-1]['dac']]
         dac_block=self.rf.dac_tiles[tile].blocks[channel]
         dac_block.NyquistZone=nqz
         return dac_block.NyquistZone

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -57,41 +57,25 @@ class QickConfig():
         lines.append("\n\tBoard: " + self.cfg['board'])
         lines.append("\n\tGlobal clocks (MHz): DAC fabric %.3f, ADC fabric %.3f, reference %.3f"%(
             self.cfg['fs_proc'], self.cfg['adc_fabric_freq'], self.cfg['refclk_freq']))
-
-        if hasattr(self,'tproc'): # this is a QickSoc
-            lines.append("\n\tGenerator switch: %d to %d"%(
-                self.switch_gen.NSL, self.switch_gen.NMI))
-            lines.append("\n\tAverager switch: %d to %d"%(
-                self.switch_avg.NSL, self.switch_avg.NMI))
-            lines.append("\n\tBuffer switch: %d to %d"%(
-                self.switch_buf.NSL, self.switch_buf.NMI))
-
-            lines.append("\n\t%d DAC channels:"%(len(self.dac_blocks)))
-            for iCh, (iTile,iBlock,fs) in enumerate(self.dac_blocks):
-                lines.append("\t%d:\ttile %d, channel %d, fs=%.3f MHz"%(iCh,iTile,iBlock,fs))
-
-            lines.append("\n\t%d ADC channels:"%(len(self.adc_blocks)))
-            for iCh, (iTile,iBlock,fs) in enumerate(self.adc_blocks):
-                lines.append("\t%d:\ttile %d, channel %d, fs=%.3f MHz"%(iCh,iTile,iBlock,fs))
-        else:
-            lines.append("\n\tSampling freqs (MHz): DAC %.3f, ADC %.3f"%(
-                self.cfg['fs_dac'], self.cfg['fs_adc']))
+        lines.append("\n\tSampling freqs (MHz): DAC %.3f, ADC %.3f"%(
+            self.cfg['fs_dac'], self.cfg['fs_adc']))
 
         lines.append("\n\tRefclk multiplier factors: %d (DAC), %d (ADC)"%(
             self.fsmult_dac, self.fsmult_adc))
         lines.append("\tFrequency resolution step: %.3f Hz"%(
             self.fstep_lcm*1e6))
 
+        lines.append("\n\t%d signal generator channels:"%(len(self.cfg['gens'])))
+        for iGen,gen in enumerate(self.cfg['gens']):
+            lines.append("\t%d:\ttProc output %d, maxlen %d"%(iGen, gen['tproc_ch'], gen['maxlen']))
+            lines.append("\t\tDAC tile %s, ch %s, %d-bit DDS, fabric=%.3f MHz, fs=%.3f MHz"%(*gen['dac'], gen['b_dds'], gen['f_fabric'], gen['fs']))
+
+        lines.append("\n\t%d readout channels:"%(len(self.cfg['readouts'])))
+        for iReadout,readout in enumerate(self.cfg['readouts']):
+            lines.append("\t%d:\tADC tile %s, ch %s, %d-bit DDS, fabric=%.3f MHz, fs=%.3f MHz"%(iReadout, *readout['adc'], readout['b_dds'], readout['f_fabric'], readout['fs']))
+            lines.append("\t\tmaxlen %d (avg) %d (decimated), trigger %d, tproc input %d"%(readout['avg_maxlen'], readout['buf_maxlen'], readout['trigger_bit'], readout['tproc_ch']))
+
         if hasattr(self,'tproc'): # this is a QickSoc
-            lines.append("\n\t%d signal generators: max length %d samples"%(len(self.gens),
-                self.gens[0].MAX_LENGTH))
-
-            lines.append("\n\t%d readout blocks"%(len(self.readouts)))
-
-            lines.append("\n\t%d average+buffer blocks: max length %d samples (averages), %d (decimated buffer)"%(len(self.cfg['avg_bufs']),
-                self.cfg['avg_bufs'][0]['avg_maxlen'], 
-                self.cfg['avg_bufs'][0]['buf_maxlen']))
-
             lines.append("\n\ttProc: %d words program memory, %d words data memory"%(2**self.tproc.PMEM_N, 2**self.tproc.DMEM_N))
             lines.append("\t\tprogram RAM: %d bytes"%(self.tproc.mem.mmio.length))
 


### PR DESCRIPTION
We had been mapping the generator and readout channel numbers based on the indices in the names of the IP blocks - this is not very smart and doesn't work when you start mixing different types of generator IPs.

One of the main functions of this numbering is getting the correct port index on the switches connecting the IPs to the DMA. Those switches provide a natural ordering for the IPs that connect to them, and so we now extract this information from the HWH parser (thanks to Graham Schelle and Shane Fleming of Xilinx for useful discussions on this).

This doesn't change any user-side code yet, but all the extracted information goes into the QickConfig dictionary. Future updates will probably change parts of qick_asm to use that information - at that point I expect there will be some API changes.