### PR TITLE
Reorganization of program configuration and pulsing code, support for new generator and readout blocks

### DIFF
--- a/qick_lib/qick/__init__.py
+++ b/qick_lib/qick/__init__.py
@@ -13,5 +13,5 @@ def bitfile_path():
 
 try:
     from .qick import QickSoc
-except:
-    print("Could not import QickSoc, probably due to not being able to load pynq package.")
+except Exception as e:
+    print("Could not import QickSoc:", e)

--- a/qick_lib/qick/__init__.py
+++ b/qick_lib/qick/__init__.py
@@ -1,16 +1,17 @@
+from .averager_program import AveragerProgram, RAveragerProgram
+from .qick_asm import QickConfig, QickProgram, deg2reg, reg2deg
 import os
 
+
 def bitfile_path():
-    if os.environ['BOARD']=='ZCU216':
+    if os.environ['BOARD'] == 'ZCU216':
         src = os.path.join(os.path.dirname(qick.__file__), 'qick_216.bit')
-    else: #assume ZCU111
+    else:  # assume ZCU111
         src = os.path.join(os.path.dirname(qick.__file__), 'qick_111.bit')
     return src
+
 
 try:
     from .qick import QickSoc
 except:
-    print ("Could not import QickSoc, probably due to not being able to load pynq package.")
-from .qick_asm import QickConfig, QickProgram, deg2reg, reg2deg
-from .averager_program import AveragerProgram, RAveragerProgram
-
+    print("Could not import QickSoc, probably due to not being able to load pynq package.")

--- a/qick_lib/qick/averager_program.py
+++ b/qick_lib/qick/averager_program.py
@@ -105,9 +105,8 @@ class AveragerProgram(QickProgram):
         self.config_readouts(soc)
         self.config_bufs(soc, enable_avg=True, enable_buf=True)
 
-        # load the this AveragerProgram into the soc's tproc
-        tproc = soc.tproc
-        tproc.load_bin_program(self.compile(debug=debug))
+        # load this program into the soc's tproc
+        self.load_program(soc, debug=debug)
 
         reps = self.cfg['reps']
         total_count = reps
@@ -272,9 +271,9 @@ class AveragerProgram(QickProgram):
         soft_avgs = self.cfg["soft_avgs"]
 
         # load the program - it's always the same, so this only needs to be done once
-        tproc = soc.tproc
-        tproc.load_bin_program(self.compile(debug=debug))
+        self.load_program(soc, debug=debug)
 
+        tproc = soc.tproc
         # for each soft average stop the processor, run and average decimated data
         for ii in tqdm(range(soft_avgs), disable=not progress):
             tproc.stop()
@@ -417,8 +416,8 @@ class RAveragerProgram(QickProgram):
         self.config_readouts(soc)
         self.config_bufs(soc, enable_avg=True, enable_buf=True)
 
-        tproc = soc.tproc
-        tproc.load_bin_program(self.compile(debug=debug))
+        # load this program into the soc's tproc
+        self.load_program(soc, debug=debug)
 
         reps, expts = self.cfg['reps'], self.cfg['expts']
 

--- a/qick_lib/qick/averager_program.py
+++ b/qick_lib/qick/averager_program.py
@@ -98,11 +98,12 @@ class AveragerProgram(QickProgram):
         if load_pulses:
             self.load_pulses(soc)
 
+        # Configure signal generators
+        self.config_gens(soc)
+
         # Configure the readout down converters
-        for ii, (ch, ro) in enumerate(self.ro_chs.items()):
-            soc.configure_readout(ch, output=ro.sel, frequency=ro.freq, gen_ch=ro.gen_ch)
-            soc.config_avg(ch, address=0, length=ro.length, enable=True)
-            soc.config_buf(ch, address=0, length=ro.length, enable=True)
+        self.config_readouts(soc)
+        self.config_bufs(soc, enable_avg=True, enable_buf=True)
 
         # load the this AveragerProgram into the soc's tproc
         tproc = soc.tproc
@@ -258,9 +259,11 @@ class AveragerProgram(QickProgram):
         if load_pulses:
             self.load_pulses(soc)
 
+        # Configure signal generators
+        self.config_gens(soc)
+
         # Configure the readout down converters
-        for ii, (ch, ro) in enumerate(self.ro_chs.items()):
-            soc.configure_readout(ch, output=ro.sel, frequency=ro.freq, gen_ch=ro.gen_ch)
+        self.config_readouts(soc)
 
         # assume every channel has the same readout length
         d_buf = np.zeros((len(self.ro_chs), 2, max(
@@ -276,9 +279,7 @@ class AveragerProgram(QickProgram):
         for ii in tqdm(range(soft_avgs), disable=not progress):
             tproc.stop()
             # Configure and enable buffer capture.
-            for ii, (ch, ro) in enumerate(self.ro_chs.items()):
-                soc.config_avg(ch, address=0, length=ro.length, enable=True)
-                soc.config_buf(ch, address=0, length=ro.length, enable=True)
+            self.config_bufs(soc, enable_avg=True, enable_buf=True)
 
             # make sure count variable is reset to 0
             tproc.single_write(addr=1, data=0)
@@ -409,11 +410,12 @@ class RAveragerProgram(QickProgram):
         if load_pulses:
             self.load_pulses(soc)
 
+        # Configure signal generators
+        self.config_gens(soc)
+
         # Configure the readout down converters
-        for ii, (ch, ro) in enumerate(self.ro_chs.items()):
-            soc.configure_readout(ch, output=ro.sel, frequency=ro.freq, gen_ch=ro.gen_ch)
-            soc.config_avg(ch, address=0, length=ro.length, enable=True)
-            soc.config_buf(ch, address=0, length=ro.length, enable=True)
+        self.config_readouts(soc)
+        self.config_bufs(soc, enable_avg=True, enable_buf=True)
 
         tproc = soc.tproc
         tproc.load_bin_program(self.compile(debug=debug))

--- a/qick_lib/qick/averager_program.py
+++ b/qick_lib/qick/averager_program.py
@@ -6,6 +6,7 @@ from tqdm import tqdm_notebook as tqdm
 import numpy as np
 import time
 
+
 class AveragerProgram(QickProgram):
     """
     AveragerProgram class is an abstract base class for programs which do loop over experiments in hardware. It consists of a template program which takes care of the loop and acquire methods that talk to the processor to stream single shot data in real-time and then reshape and average it appropriately.
@@ -15,50 +16,51 @@ class AveragerProgram(QickProgram):
     :param cfg: Configuration dictionary
     :type cfg: dict
     """
+
     def __init__(self, soccfg, cfg):
         """
         Constructor for the AveragerProgram, calls make program at the end so for classes that inherit from this if you want it to do something before the program is made and compiled either do it before calling this __init__ or put it in the initialize method.
         """
         super().__init__(soccfg)
-        self.cfg=cfg
+        self.cfg = cfg
         self.make_program()
-    
+
     def initialize(self):
         """
         Abstract method for initializing the program and can include any instructions that are executed once at the beginning of the program.
         """
         pass
-    
+
     def body(self):
         """
         Abstract method for the body of the program
         """
         pass
-    
+
     def make_program(self):
         """
         A template program which repeats the instructions defined in the body() method the number of times specified in self.cfg["reps"].
         """
-        p=self
-        
-        rjj=14
-        rcount=15
+        p = self
+
+        rjj = 14
+        rcount = 15
         p.initialize()
-        p.regwi (0, rcount,0)
-        p.regwi (0, rjj, self.cfg["reps"]-1)
+        p.regwi(0, rcount, 0)
+        p.regwi(0, rjj, self.cfg["reps"]-1)
         p.label("LOOP_J")
 
         p.body()
 
-        p.mathi(0,rcount,rcount,"+",1)
-        
-        p.memwi(0,rcount,1)
-                
+        p.mathi(0, rcount, rcount, "+", 1)
+
+        p.memwi(0, rcount, 1)
+
         p.loopnz(0, rjj, 'LOOP_J')
-       
-        p.end()        
-        
-    def acquire_round(self, soc, threshold=None, angle=[0,0], readouts_per_experiment=1, save_experiments=[0], load_pulses=True, progress=False, debug=False):
+
+        p.end()
+
+    def acquire_round(self, soc, threshold=None, angle=[0, 0], readouts_per_experiment=1, save_experiments=[0], load_pulses=True, progress=False, debug=False):
         """
         This method optionally loads pulses on to the SoC, configures the ADC readouts, loads the machine code representation of the AveragerProgram onto the SoC, starts the program and streams the data into the Python, returning it as a set of numpy arrays.
 
@@ -85,68 +87,72 @@ class AveragerProgram(QickProgram):
             - avg_di (:py:class:`list`) - list of lists of averaged accumulated I data for ADCs 0 and 1
             - avg_dq (:py:class:`list`) - list of lists of averaged accumulated Q data for ADCs 0 and 1
         """
-        #Load the pulses from the program into the soc
-        if load_pulses: 
+        # Load the pulses from the program into the soc
+        if load_pulses:
             self.load_pulses(soc)
-        
-        #Configure the readout down converters
-        for ii,(ch,ro) in enumerate(self.ro_chs.items()):
+
+        # Configure the readout down converters
+        for ii, (ch, ro) in enumerate(self.ro_chs.items()):
             soc.configure_readout(ch, output=ro.sel, frequency=ro.freq)
             soc.config_avg(ch, address=0, length=ro.length, enable=True)
             soc.config_buf(ch, address=0, length=ro.length, enable=True)
 
-        #load the this AveragerProgram into the soc's tproc
-        tproc=soc.tproc
+        # load the this AveragerProgram into the soc's tproc
+        tproc = soc.tproc
         tproc.load_bin_program(self.compile(debug=debug))
-        
-        
-        reps = self.cfg['reps']
-        total_count=reps
-        count = 0
-        t = tqdm(total=total_count, disable=not progress) #progress bar
-        
-        d_buf = np.zeros((len(self.ro_chs),2,total_count))
-        stats_list=[]
 
-        streamer=soc.streamer
-        streamer.start_readout(total_count, counter_addr=1, ch_list=list(self.ro_chs))
+        reps = self.cfg['reps']
+        total_count = reps
+        count = 0
+        t = tqdm(total=total_count, disable=not progress)  # progress bar
+
+        d_buf = np.zeros((len(self.ro_chs), 2, total_count))
+        stats_list = []
+
+        streamer = soc.streamer
+        streamer.start_readout(total_count, counter_addr=1,
+                               ch_list=list(self.ro_chs))
         while streamer.readout_alive():
             new_data = streamer.poll_data()
-            for d,s in new_data:
+            for d, s in new_data:
                 new_points = d.shape[2]
-                d_buf[:,:,count:count+new_points] = d
+                d_buf[:, :, count:count+new_points] = d
                 count += new_points
                 stats_list.append(s)
                 t.update(new_points)
         t.close()
-        self.stats=stats_list
+        self.stats = stats_list
 
         # reformat the data into separate I and Q arrays
         di_buf = np.stack([d_buf[i][0] for i in range(len(self.ro_chs))])
         dq_buf = np.stack([d_buf[i][1] for i in range(len(self.ro_chs))])
-                    
-        #save results to class in case you want to look at it later or for analysis
-        self.di_buf=di_buf
-        self.dq_buf=dq_buf
+
+        # save results to class in case you want to look at it later or for analysis
+        self.di_buf = di_buf
+        self.dq_buf = dq_buf
 
         if threshold is not None:
-            self.shots=self.get_single_shots(di_buf,dq_buf, threshold, angle)
+            self.shots = self.get_single_shots(
+                di_buf, dq_buf, threshold, angle)
 
-        avg_di=np.zeros((len(self.ro_chs),len(save_experiments)))
-        avg_dq=np.zeros((len(self.ro_chs),len(save_experiments)))
+        avg_di = np.zeros((len(self.ro_chs), len(save_experiments)))
+        avg_dq = np.zeros((len(self.ro_chs), len(save_experiments)))
 
-        for nn,ii in enumerate(save_experiments):
-            for i_ch,(ch,ro) in enumerate(self.ro_chs.items()):
+        for nn, ii in enumerate(save_experiments):
+            for i_ch, (ch, ro) in enumerate(self.ro_chs.items()):
                 if threshold is None:
-                    avg_di[i_ch][nn]=np.sum(di_buf[i_ch][ii::readouts_per_experiment])/(reps)/ro.length
-                    avg_dq[i_ch][nn]=np.sum(dq_buf[i_ch][ii::readouts_per_experiment])/(reps)/ro.length
+                    avg_di[i_ch][nn] = np.sum(
+                        di_buf[i_ch][ii::readouts_per_experiment])/(reps)/ro.length
+                    avg_dq[i_ch][nn] = np.sum(
+                        dq_buf[i_ch][ii::readouts_per_experiment])/(reps)/ro.length
                 else:
-                    avg_di[i_ch][nn]=np.sum(self.shots[i_ch][ii::readouts_per_experiment])/(reps)
-                    avg_dq=np.zeros(avg_di.shape)
+                    avg_di[i_ch][nn] = np.sum(
+                        self.shots[i_ch][ii::readouts_per_experiment])/(reps)
+                    avg_dq = np.zeros(avg_di.shape)
 
         return avg_di, avg_dq
-    
-    def acquire(self, soc, threshold=None, angle=[0,0], readouts_per_experiment=1, save_experiments=[0], load_pulses=True, progress=False, debug=False):
+
+    def acquire(self, soc, threshold=None, angle=[0, 0], readouts_per_experiment=1, save_experiments=[0], load_pulses=True, progress=False, debug=False):
         """
         This method optionally loads pulses on to the SoC, configures the ADC readouts, loads the machine code representation of the AveragerProgram onto the SoC, starts the program and streams the data into the Python, returning it as a set of numpy arrays.
         config requirements:
@@ -174,22 +180,23 @@ class AveragerProgram(QickProgram):
             - avg_dq (:py:class:`list`) - list of lists of averaged accumulated Q data for ADCs 0 and 1
         """
 
-        if "rounds" not in self.cfg or self.cfg["rounds"]==1:
-            return self.acquire_round(soc,threshold=threshold, angle=angle, load_pulses=load_pulses,progress=progress, debug=debug)
-        
-        avg_di=None
-        for ii in tqdm(range (self.cfg["rounds"]), disable=not progress):           
-            avg_di0, avg_dq0=self.acquire_round(soc,threshold=threshold, angle=angle, load_pulses=load_pulses,progress=False, debug=debug)
-            
+        if "rounds" not in self.cfg or self.cfg["rounds"] == 1:
+            return self.acquire_round(soc, threshold=threshold, angle=angle, load_pulses=load_pulses, progress=progress, debug=debug)
+
+        avg_di = None
+        for ii in tqdm(range(self.cfg["rounds"]), disable=not progress):
+            avg_di0, avg_dq0 = self.acquire_round(
+                soc, threshold=threshold, angle=angle, load_pulses=load_pulses, progress=False, debug=debug)
+
             if avg_di is None:
                 avg_di, avg_dq = avg_di0, avg_dq0
             else:
-                avg_di+= avg_di0
-                avg_dq+= avg_dq0
-                
+                avg_di += avg_di0
+                avg_dq += avg_dq0
+
         return avg_di/self.cfg["rounds"], avg_dq/self.cfg["rounds"]
-    
-    def get_single_shots(self, di, dq, threshold, angle=[0,0]):
+
+    def get_single_shots(self, di, dq, threshold, angle=[0, 0]):
         """
         This method converts the raw I/Q data to single shots according to the threshold and rotation angle
 
@@ -208,8 +215,8 @@ class AveragerProgram(QickProgram):
         """
 
         if type(threshold) is int:
-            threshold=[threshold,threshold]            
-        return np.array([np.heaviside((di[i]*np.cos(angle[i]) - dq[i]*np.sin(angle[i]))/self.ro_chs[ch].length-threshold[i],0) for i,ch in enumerate(self.ro_chs)])
+            threshold = [threshold, threshold]
+        return np.array([np.heaviside((di[i]*np.cos(angle[i]) - dq[i]*np.sin(angle[i]))/self.ro_chs[ch].length-threshold[i], 0) for i, ch in enumerate(self.ro_chs)])
 
     def acquire_decimated(self, soc, load_pulses=True, progress=True, debug=False):
         """
@@ -230,47 +237,51 @@ class AveragerProgram(QickProgram):
              - iq0 (:py:class:`list`) - list of lists of averaged decimated I and Q data ADC 0
              - iq1 (:py:class:`list`) - list of lists of averaged decimated I and Q data ADC 1
          """
-        #set reps to 1 since we are going to use soft averages
+        # set reps to 1 since we are going to use soft averages
         if "reps" not in self.cfg or self.cfg["reps"] != 1:
-            print ("Warning reps is not set to 1, and this acquire method expects reps=1")
-        
-        #load pulses onto soc
-        if load_pulses: 
+            print("Warning reps is not set to 1, and this acquire method expects reps=1")
+
+        # load pulses onto soc
+        if load_pulses:
             self.load_pulses(soc)
 
-        #Configure the readout down converters
-        for ii,(ch,ro) in enumerate(self.ro_chs.items()):
+        # Configure the readout down converters
+        for ii, (ch, ro) in enumerate(self.ro_chs.items()):
             soc.configure_readout(ch, output=ro.sel, frequency=ro.freq)
-        
-        # assume every channel has the same readout length
-        d_buf = np.zeros((len(self.ro_chs), 2, max([ro.length for ro in self.ro_chs.values()])))
 
-        soft_avgs=self.cfg["soft_avgs"]        
+        # assume every channel has the same readout length
+        d_buf = np.zeros((len(self.ro_chs), 2, max(
+            [ro.length for ro in self.ro_chs.values()])))
+
+        soft_avgs = self.cfg["soft_avgs"]
 
         # load the program - it's always the same, so this only needs to be done once
-        tproc=soc.tproc
+        tproc = soc.tproc
         tproc.load_bin_program(self.compile(debug=debug))
 
-        #for each soft average stop the processor, run and average decimated data
-        for ii in tqdm(range(soft_avgs),disable=not progress):
+        # for each soft average stop the processor, run and average decimated data
+        for ii in tqdm(range(soft_avgs), disable=not progress):
             tproc.stop()
             # Configure and enable buffer capture.
-            for ii,(ch,ro) in enumerate(self.ro_chs.items()):
+            for ii, (ch, ro) in enumerate(self.ro_chs.items()):
                 soc.config_avg(ch, address=0, length=ro.length, enable=True)
                 soc.config_buf(ch, address=0, length=ro.length, enable=True)
 
-            tproc.single_write(addr= 1,data=0)   #make sure count variable is reset to 0       
-            tproc.start() #runs the assembly program
+            # make sure count variable is reset to 0
+            tproc.single_write(addr=1, data=0)
+            tproc.start()  # runs the assembly program
 
-            count=0
-            while count<1:
-                count = tproc.single_read(addr= 1)
-                
-            for ii,(ch,ro) in enumerate(self.ro_chs.items()):
-                d_buf[ii] += soc.get_decimated(ch=ch, address=0, length=ro.length)
-            
+            count = 0
+            while count < 1:
+                count = tproc.single_read(addr=1)
+
+            for ii, (ch, ro) in enumerate(self.ro_chs.items()):
+                d_buf[ii] += soc.get_decimated(ch=ch,
+                                               address=0, length=ro.length)
+
         return [d/soft_avgs for d in d_buf]
-    
+
+
 class RAveragerProgram(QickProgram):
     """
     RAveragerProgram class, for qubit experiments that sweep over a variable (whose value is stored in expt_pts).
@@ -280,65 +291,66 @@ class RAveragerProgram(QickProgram):
     :param cfg: Configuration dictionary
     :type cfg: dict
     """
+
     def __init__(self, soccfg, cfg):
         """
         Constructor for the RAveragerProgram, calls make program at the end so for classes that inherit from this if you want it to do something before the program is made and compiled either do it before calling this __init__ or put it in the initialize method.
         """
         super().__init__(soccfg)
-        self.cfg=cfg
+        self.cfg = cfg
         self.make_program()
-    
+
     def initialize(self):
         """
         Abstract method for initializing the program and can include any instructions that are executed once at the beginning of the program.
         """
         pass
-    
+
     def body(self):
         """
         Abstract method for the body of the program
         """
         pass
-    
+
     def update(self):
         """
         Abstract method for updating the program
         """
         pass
-    
+
     def make_program(self):
         """
         A template program which repeats the instructions defined in the body() method the number of times specified in self.cfg["reps"].
         """
-        p=self
-        
-        rcount=13
-        rii=14
-        rjj=15
+        p = self
+
+        rcount = 13
+        rii = 14
+        rjj = 15
 
         p.initialize()
 
-        p.regwi(0, rcount,0)
-        
-        p.regwi (0, rii, self.cfg["expts"]-1 )
-        p.label("LOOP_I")    
+        p.regwi(0, rcount, 0)
 
-        p.regwi (0, rjj, self.cfg["reps"]-1)
+        p.regwi(0, rii, self.cfg["expts"]-1)
+        p.label("LOOP_I")
+
+        p.regwi(0, rjj, self.cfg["reps"]-1)
         p.label("LOOP_J")
 
         p.body()
 
-        p.mathi(0,rcount,rcount,"+",1)
-        
-        p.memwi(0,rcount,1)
-                
+        p.mathi(0, rcount, rcount, "+", 1)
+
+        p.memwi(0, rcount, 1)
+
         p.loopnz(0, rjj, 'LOOP_J')
 
         p.update()
-        
-        p.loopnz(0, rii, "LOOP_I")    
 
-        p.end()        
+        p.loopnz(0, rii, "LOOP_I")
+
+        p.end()
 
     def get_expt_pts(self):
         """
@@ -348,8 +360,8 @@ class RAveragerProgram(QickProgram):
         :rtype: array
         """
         return self.cfg["start"]+np.arange(self.cfg['expts'])*self.cfg["step"]
-        
-    def acquire_round(self, soc, threshold=None, angle=[0,0],  readouts_per_experiment=1, save_experiments=[0], load_pulses=True, progress=False, debug=False):
+
+    def acquire_round(self, soc, threshold=None, angle=[0, 0],  readouts_per_experiment=1, save_experiments=[0], load_pulses=True, progress=False, debug=False):
         """
          This method optionally loads pulses on to the SoC, configures the ADC readouts, loads the machine code representation of the AveragerProgram onto the SoC, starts the program and streams the data into the Python, returning it as a set of numpy arrays.
 
@@ -377,67 +389,72 @@ class RAveragerProgram(QickProgram):
              - avg_dq (:py:class:`list`) - list of lists of averaged accumulated Q data for ADCs 0 and 1
          """
 
-        if load_pulses: 
+        if load_pulses:
             self.load_pulses(soc)
-        
-        #Configure the readout down converters
-        for ii,(ch,ro) in enumerate(self.ro_chs.items()):
+
+        # Configure the readout down converters
+        for ii, (ch, ro) in enumerate(self.ro_chs.items()):
             soc.configure_readout(ch, output=ro.sel, frequency=ro.freq)
             soc.config_avg(ch, address=0, length=ro.length, enable=True)
             soc.config_buf(ch, address=0, length=ro.length, enable=True)
 
-        tproc=soc.tproc
+        tproc = soc.tproc
         tproc.load_bin_program(self.compile(debug=debug))
-        
-        reps,expts = self.cfg['reps'],self.cfg['expts']
-        
-        count=0
-        total_count=reps*expts*readouts_per_experiment
 
-        d_buf = np.zeros((len(self.ro_chs),2,total_count))
-        streamer=soc.streamer
-        stats_list=[]
+        reps, expts = self.cfg['reps'], self.cfg['expts']
+
+        count = 0
+        total_count = reps*expts*readouts_per_experiment
+
+        d_buf = np.zeros((len(self.ro_chs), 2, total_count))
+        streamer = soc.streamer
+        stats_list = []
 
         with tqdm(total=total_count, disable=not progress) as pbar:
-            streamer.start_readout(total_count, counter_addr=1, ch_list=list(self.ro_chs), reads_per_count=readouts_per_experiment)
+            streamer.start_readout(total_count, counter_addr=1, ch_list=list(
+                self.ro_chs), reads_per_count=readouts_per_experiment)
             while streamer.readout_alive():
                 new_data = streamer.poll_data()
-                for d,s in new_data:
+                for d, s in new_data:
                     new_points = d.shape[2]
-                    d_buf[:,:,count:count+new_points] = d
+                    d_buf[:, :, count:count+new_points] = d
                     count += new_points
                     stats_list.append(s)
                     pbar.update(new_points)
-            self.stats=stats_list
+            self.stats = stats_list
 
         # reformat the data into separate I and Q arrays
         di_buf = np.stack([d_buf[i][0] for i in range(len(self.ro_chs))])
         dq_buf = np.stack([d_buf[i][1] for i in range(len(self.ro_chs))])
 
-        #save results to class in case you want to look at it later or for analysis
-        self.di_buf=di_buf
-        self.dq_buf=dq_buf
-        
-        if threshold is not None:
-            self.shots=self.get_single_shots(di_buf,dq_buf, threshold, angle)
-                
-        expt_pts=self.get_expt_pts()
-        
-        avg_di=np.zeros((len(self.ro_chs),len(save_experiments), expts))
-        avg_dq=np.zeros((len(self.ro_chs),len(save_experiments), expts))
+        # save results to class in case you want to look at it later or for analysis
+        self.di_buf = di_buf
+        self.dq_buf = dq_buf
 
-        for nn,ii in enumerate(save_experiments):
-            for i_ch,(ch,ro) in enumerate(self.ro_chs.items()):
+        if threshold is not None:
+            self.shots = self.get_single_shots(
+                di_buf, dq_buf, threshold, angle)
+
+        expt_pts = self.get_expt_pts()
+
+        avg_di = np.zeros((len(self.ro_chs), len(save_experiments), expts))
+        avg_dq = np.zeros((len(self.ro_chs), len(save_experiments), expts))
+
+        for nn, ii in enumerate(save_experiments):
+            for i_ch, (ch, ro) in enumerate(self.ro_chs.items()):
                 if threshold is None:
-                    avg_di[i_ch][nn]=np.sum(di_buf[i_ch][ii::readouts_per_experiment].reshape((expts, reps)),1)/(reps)/ro.length
-                    avg_dq[i_ch][nn]=np.sum(dq_buf[i_ch][ii::readouts_per_experiment].reshape((expts, reps)),1)/(reps)/ro.length
+                    avg_di[i_ch][nn] = np.sum(di_buf[i_ch][ii::readouts_per_experiment].reshape(
+                        (expts, reps)), 1)/(reps)/ro.length
+                    avg_dq[i_ch][nn] = np.sum(dq_buf[i_ch][ii::readouts_per_experiment].reshape(
+                        (expts, reps)), 1)/(reps)/ro.length
                 else:
-                    avg_di[i_ch][nn]=np.sum(self.shots[i_ch][ii::readouts_per_experiment].reshape((expts, reps)),1)/(reps)
-                    avg_dq=np.zeros(avg_di.shape)
+                    avg_di[i_ch][nn] = np.sum(
+                        self.shots[i_ch][ii::readouts_per_experiment].reshape((expts, reps)), 1)/(reps)
+                    avg_dq = np.zeros(avg_di.shape)
 
         return expt_pts, avg_di, avg_dq
 
-    def get_single_shots(self, di, dq, threshold, angle=[0,0]):
+    def get_single_shots(self, di, dq, threshold, angle=[0, 0]):
         """
         This method converts the raw I/Q data to single shots according to the threshold and rotation angle
 
@@ -456,10 +473,10 @@ class RAveragerProgram(QickProgram):
         """
 
         if type(threshold) is int:
-            threshold=[threshold,threshold]            
-        return np.array([np.heaviside((di[i]*np.cos(angle[i]) - dq[i]*np.sin(angle[i]))/self.ro_chs[ch].length-threshold[i],0) for i,ch in enumerate(self.ro_chs)])
-                    
-    def acquire(self, soc, threshold=None, angle=[0,0], load_pulses=True, readouts_per_experiment=1, save_experiments=[0], progress=False, debug=False):
+            threshold = [threshold, threshold]
+        return np.array([np.heaviside((di[i]*np.cos(angle[i]) - dq[i]*np.sin(angle[i]))/self.ro_chs[ch].length-threshold[i], 0) for i, ch in enumerate(self.ro_chs)])
+
+    def acquire(self, soc, threshold=None, angle=[0, 0], load_pulses=True, readouts_per_experiment=1, save_experiments=[0], progress=False, debug=False):
         """
         This method optionally loads pulses on to the SoC, configures the ADC readouts, loads the machine code representation of the AveragerProgram onto the SoC, starts the program and streams the data into the Python, returning it as a set of numpy arrays.
         config requirements:
@@ -486,18 +503,18 @@ class RAveragerProgram(QickProgram):
             - avg_di (:py:class:`list`) - list of lists of averaged accumulated I data for ADCs 0 and 1
             - avg_dq (:py:class:`list`) - list of lists of averaged accumulated Q data for ADCs 0 and 1
         """
-        if "rounds" not in self.cfg or self.cfg["rounds"]==1:
+        if "rounds" not in self.cfg or self.cfg["rounds"] == 1:
             return self.acquire_round(soc, threshold=threshold, angle=angle, readouts_per_experiment=readouts_per_experiment, save_experiments=save_experiments, load_pulses=load_pulses, progress=progress, debug=debug)
-        
-        avg_di=None
-        for ii in tqdm(range (self.cfg["rounds"]), disable=not progress):
-            expt_pts, avg_di0, avg_dq0=self.acquire_round(soc, threshold=threshold, angle=angle, readouts_per_experiment=readouts_per_experiment, save_experiments=save_experiments, load_pulses=load_pulses, progress=False, debug=debug)
-            
+
+        avg_di = None
+        for ii in tqdm(range(self.cfg["rounds"]), disable=not progress):
+            expt_pts, avg_di0, avg_dq0 = self.acquire_round(soc, threshold=threshold, angle=angle, readouts_per_experiment=readouts_per_experiment,
+                                                            save_experiments=save_experiments, load_pulses=load_pulses, progress=False, debug=debug)
+
             if avg_di is None:
-                avg_di, avg_dq= avg_di0, avg_dq0
+                avg_di, avg_dq = avg_di0, avg_dq0
             else:
-                avg_di+= avg_di0
-                avg_dq+= avg_dq0
-        
-                
+                avg_di += avg_di0
+                avg_dq += avg_dq0
+
         return expt_pts, avg_di/self.cfg["rounds"], avg_dq/self.cfg["rounds"]

--- a/qick_lib/qick/averager_program.py
+++ b/qick_lib/qick/averager_program.py
@@ -100,7 +100,7 @@ class AveragerProgram(QickProgram):
 
         # Configure the readout down converters
         for ii, (ch, ro) in enumerate(self.ro_chs.items()):
-            soc.configure_readout(ch, output=ro.sel, frequency=ro.freq)
+            soc.configure_readout(ch, output=ro.sel, frequency=ro.freq, gen_ch=ro.gen_ch)
             soc.config_avg(ch, address=0, length=ro.length, enable=True)
             soc.config_buf(ch, address=0, length=ro.length, enable=True)
 
@@ -260,7 +260,7 @@ class AveragerProgram(QickProgram):
 
         # Configure the readout down converters
         for ii, (ch, ro) in enumerate(self.ro_chs.items()):
-            soc.configure_readout(ch, output=ro.sel, frequency=ro.freq)
+            soc.configure_readout(ch, output=ro.sel, frequency=ro.freq, gen_ch=ro.gen_ch)
 
         # assume every channel has the same readout length
         d_buf = np.zeros((len(self.ro_chs), 2, max(
@@ -411,7 +411,7 @@ class RAveragerProgram(QickProgram):
 
         # Configure the readout down converters
         for ii, (ch, ro) in enumerate(self.ro_chs.items()):
-            soc.configure_readout(ch, output=ro.sel, frequency=ro.freq)
+            soc.configure_readout(ch, output=ro.sel, frequency=ro.freq, gen_ch=ro.gen_ch)
             soc.config_avg(ch, address=0, length=ro.length, enable=True)
             soc.config_buf(ch, address=0, length=ro.length, enable=True)
 

--- a/qick_lib/qick/helpers.py
+++ b/qick_lib/qick/helpers.py
@@ -3,7 +3,8 @@ Support functions.
 """
 import numpy as np
 
-def gauss(mu=0,si=25,length=100,maxv=30000):
+
+def gauss(mu=0, si=25, length=100, maxv=30000):
     """
     Create a numpy array containing a Gaussian function
 
@@ -18,12 +19,13 @@ def gauss(mu=0,si=25,length=100,maxv=30000):
     :return: Numpy array containing a Gaussian function
     :rtype: array
     """
-    x = np.arange(0,length)
+    x = np.arange(0, length)
     y = 1/(2*np.pi*si**2)*np.exp(-(x-mu)**2/si**2)
     y = y/np.max(y)*maxv
     return y
 
-def triang(length=100,maxv=30000):
+
+def triang(length=100, maxv=30000):
     """
     Create a numpy array containing a triangle function
 
@@ -34,11 +36,12 @@ def triang(length=100,maxv=30000):
     :return: Numpy array containing a triangle function
     :rtype: array
     """
-    y1 = np.arange(0,length/2)
-    y2 = np.flip(y1,0)
-    y = np.concatenate((y1,y2))
+    y1 = np.arange(0, length/2)
+    y2 = np.flip(y1, 0)
+    y = np.concatenate((y1, y2))
     y = y/np.max(y)*maxv
     return y
+
 
 def trace_net(parser, blockname, portname):
     """
@@ -59,7 +62,8 @@ def trace_net(parser, blockname, portname):
     # the net connected to this port
     netname = parser.pins[fullport]
     # get the list of other ports on this net, discard the port we started at and ILA ports
-    return [x.split('/') for x in parser.nets[netname] if x!=fullport and 'system_ila_' not in x]
+    return [x.split('/') for x in parser.nets[netname] if x != fullport and 'system_ila_' not in x]
+
 
 def get_fclk(parser, blockname, portname):
     """
@@ -74,9 +78,11 @@ def get_fclk(parser, blockname, portname):
     :return: frequency in MHz
     :rtype: float
     """
-    xmlpath="./MODULES/MODULE[@FULLNAME='/{0}']/PORTS/PORT[@NAME='{1}']".format(blockname,portname)
+    xmlpath = "./MODULES/MODULE[@FULLNAME='/{0}']/PORTS/PORT[@NAME='{1}']".format(
+        blockname, portname)
     port = parser.root.find(xmlpath)
     return float(port.get('CLKFREQUENCY'))/1e6
+
 
 class BusParser:
     def __init__(self, parser):

--- a/qick_lib/qick/parser.py
+++ b/qick_lib/qick/parser.py
@@ -4,7 +4,9 @@ Function to parse tProc assembly language programs.
 import re
 
 # Function to parse program.
-def parse_prog(file="prog.asm",outfmt="bin"):
+
+
+def parse_prog(file="prog.asm", outfmt="bin"):
     """
     Parses the .asm assembly language tProc program into a specified output format (binary or hex)
 
@@ -22,34 +24,33 @@ def parse_prog(file="prog.asm",outfmt="bin"):
     instList = {}
 
     # I-type.
-    instList['pushi']   = {'bin':'00010000'}
-    instList['popi']    = {'bin':'00010001'}
-    instList['mathi']   = {'bin':'00010010'}
-    instList['seti']    = {'bin':'00010011'}
-    instList['synci']   = {'bin':'00010100'}
-    instList['waiti']   = {'bin':'00010101'}
-    instList['bitwi']   = {'bin':'00010110'}
-    instList['memri']   = {'bin':'00010111'}
-    instList['memwi']   = {'bin':'00011000'}
-    instList['regwi']   = {'bin':'00011001'}
-    instList['setbi']   = {'bin':'00011010'}
+    instList['pushi'] = {'bin': '00010000'}
+    instList['popi'] = {'bin': '00010001'}
+    instList['mathi'] = {'bin': '00010010'}
+    instList['seti'] = {'bin': '00010011'}
+    instList['synci'] = {'bin': '00010100'}
+    instList['waiti'] = {'bin': '00010101'}
+    instList['bitwi'] = {'bin': '00010110'}
+    instList['memri'] = {'bin': '00010111'}
+    instList['memwi'] = {'bin': '00011000'}
+    instList['regwi'] = {'bin': '00011001'}
+    instList['setbi'] = {'bin': '00011010'}
 
     # J-type.
-    instList['loopnz']  = {'bin':'00110000'}
-    instList['condj']   = {'bin':'00110001'}
-    instList['end']     = {'bin':'00111111'}
+    instList['loopnz'] = {'bin': '00110000'}
+    instList['condj'] = {'bin': '00110001'}
+    instList['end'] = {'bin': '00111111'}
 
     # R-type.
-    instList['math']    = {'bin':'01010000'}
-    instList['set']     = {'bin':'01010001'}
-    instList['sync']    = {'bin':'01010010'}
-    instList['read']    = {'bin':'01010011'}
-    instList['wait']    = {'bin':'01010100'}
-    instList['bitw']    = {'bin':'01010101'}
-    instList['memr']    = {'bin':'01010110'}
-    instList['memw']    = {'bin':'01010111'}
-    instList['setb']    = {'bin':'01011000'}
-
+    instList['math'] = {'bin': '01010000'}
+    instList['set'] = {'bin': '01010001'}
+    instList['sync'] = {'bin': '01010010'}
+    instList['read'] = {'bin': '01010011'}
+    instList['wait'] = {'bin': '01010100'}
+    instList['bitw'] = {'bin': '01010101'}
+    instList['memr'] = {'bin': '01010110'}
+    instList['memw'] = {'bin': '01010111'}
+    instList['setb'] = {'bin': '01011000'}
 
     # Structures for symbols and program.
     progList = {}
@@ -58,27 +59,27 @@ def parse_prog(file="prog.asm",outfmt="bin"):
     ##############################
     ### Read program from file ###
     ##############################
-    fd = open(file,"r")
+    fd = open(file, "r")
     addr = 0
     for line in fd:
         # Match comments.
         m = re.search("^\s*//", line)
-        
+
         # If there is a match.
         if m:
-            #print(line)
+            # print(line)
             a = 1
-        
+
         else:
             # Match instructions.
             jump_re = "^((.+):)?"
-            inst_re_I = "pushi|popi|mathi|seti|synci|waiti|bitwi|memri|memwi|regwi|setbi|";
-            inst_re_J = "loopnz|condj|end|";
-            inst_re_R = "math|set|sync|read|wait|bitw|memr|memw|setb";
-            inst_re = "\s*(" + inst_re_I + inst_re_J + inst_re_R + ")\s+(.+);";
+            inst_re_I = "pushi|popi|mathi|seti|synci|waiti|bitwi|memri|memwi|regwi|setbi|"
+            inst_re_J = "loopnz|condj|end|"
+            inst_re_R = "math|set|sync|read|wait|bitw|memr|memw|setb"
+            inst_re = "\s*(" + inst_re_I + inst_re_J + inst_re_R + ")\s+(.+);"
             comp_re = jump_re + inst_re
-            m = re.search(comp_re, line, flags = re.MULTILINE)
-    
+            m = re.search(comp_re, line, flags=re.MULTILINE)
+
             # If there is a match.
             if m:
                 # Tagged instruction for jump.
@@ -86,99 +87,99 @@ def parse_prog(file="prog.asm",outfmt="bin"):
                     symb = m.group(2)
                     inst = m.group(3)
                     args = m.group(4)
-            
+
                     # Add symbol to symbList.
-                    symbList[symb] = addr;
-            
+                    symbList[symb] = addr
+
                     # Add instruction to progList.
-                    progList[addr] = {'inst':inst,'args':args}
-            
+                    progList[addr] = {'inst': inst, 'args': args}
+
                     # Increment address.
                     addr = addr + 1
-            
+
                 # Normal instruction.
                 else:
                     inst = m.group(3)
                     args = m.group(4)
-            
+
                     # Add instruction to progList.
-                    progList[addr] = {'inst':inst,'args':args}
+                    progList[addr] = {'inst': inst, 'args': args}
 
                     # Increment address.
                     addr = addr + 1
-                
+
             # Check special case of "end" instruction.
             else:
-                m = re.search("\s*(end);",line)
+                m = re.search("\s*(end);", line)
 
                 # If there is a match.
                 if m:
                     # Add instruction to progList.
-                    progList[addr] = {'inst':'end','args':''}
-                
+                    progList[addr] = {'inst': 'end', 'args': ''}
+
                     # Increment address.
                     addr = addr + 1
 
     #########################
     ### Support functions ###
     #########################
-    def unsigned2bin(strin,bits=8):
+    def unsigned2bin(strin, bits=8):
         maxv = 2**bits - 1
-    
+
         # Check if hex string.
-        m = re.search("^0x", strin, flags = re.MULTILINE)
+        m = re.search("^0x", strin, flags=re.MULTILINE)
         if m:
             dec = int(strin, 16)
         else:
             dec = int(strin, 10)
-        
+
         # Check max.
         if dec > maxv:
-            print("Error: number %d is bigger than %d" %(dec,maxv))
+            print("Error: number %d is bigger than %d" % (dec, maxv))
             return None
-    
+
         # Convert to binary.
         fmt = "{0:0" + str(bits) + "b}"
         binv = fmt.format(dec)
-        
+
         return binv
-    
-    def integer2bin(strin,bits=8):
+
+    def integer2bin(strin, bits=8):
         minv = -2**(bits-1)
         maxv = 2**(bits-1) - 1
-    
+
         # Check if hex string.
-        m = re.search("^0x", strin, flags = re.MULTILINE)
+        m = re.search("^0x", strin, flags=re.MULTILINE)
         if m:
             # Special case for hex number.
             dec = int(strin, 16)
-            
+
             # Convert to binary.
             fmt = "{0:0" + str(bits) + "b}"
             binv = fmt.format(dec)
-        
+
             return binv
         else:
             dec = int(strin, 10)
-        
+
         # Check max.
         if dec < minv:
-            print("Error: number %d is smaller than %d" %(dec,minv))
+            print("Error: number %d is smaller than %d" % (dec, minv))
             return None
-        
+
         # Check max.
         if dec > maxv:
-            print("Error: number %d is bigger than %d" %(dec,maxv))
+            print("Error: number %d is bigger than %d" % (dec, maxv))
             return None
-    
+
         # Check if number is negative.
         if dec < 0:
             dec = dec + 2**bits
-            
+
         # Convert to binary.
         fmt = "{0:0" + str(bits) + "b}"
         binv = fmt.format(dec)
-        
+
         return binv
 
     def op2bin(op):
@@ -228,606 +229,634 @@ def parse_prog(file="prog.asm",outfmt="bin"):
     for e in progList:
         inst = progList[e]['inst']
         args = progList[e]['args']
-        
+
         # I-type: three registers and an immediate value.
         # I-type:<inst>:page:channel:oper:ra:rb:rc:imm
-    
+
         # pushi p, $ra, $rb, imm
         if inst == 'pushi':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*,\s*(\-?\d+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*,\s*(\-?\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
                 page = m.group(1)
-                ra   = m.group(2)
-                rb   = m.group(3)
-                imm  = m.group(4)
-            
-                # Add entry into structure.
-                progList[e]['inst_parse'] = "I-type:pushi:" + page + ":0:0:" + rb + ":" + ra + ":0:" + imm
-        
-            # Error: bad instruction format.
-            else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))
-            
-        # popi p, $r
-        elif inst == 'popi':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)";
-            m = re.search(comp_re, args)
-        
-            # If there is a match.
-            if m:
-                page = m.group(1)
-                r    = m.group(2)
+                ra = m.group(2)
+                rb = m.group(3)
+                imm = m.group(4)
 
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "I-type:popi:" + page + ":0:0:" + r + ":0:0:0"
-            
+                progList[e]['inst_parse'] = "I-type:pushi:" + \
+                    page + ":0:0:" + rb + ":" + ra + ":0:" + imm
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))
-            
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
+        # popi p, $r
+        elif inst == 'popi':
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)"
+            m = re.search(comp_re, args)
+
+            # If there is a match.
+            if m:
+                page = m.group(1)
+                r = m.group(2)
+
+                # Add entry into structure.
+                progList[e]['inst_parse'] = "I-type:popi:" + \
+                    page + ":0:0:" + r + ":0:0:0"
+
+            # Error: bad instruction format.
+            else:
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # mathi p, $ra, $rb oper imm
         if inst == 'mathi':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*([\+\-\*])\s*(0?x?\-?[0-9a-fA-F]+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*([\+\-\*])\s*(0?x?\-?[0-9a-fA-F]+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
                 page = m.group(1)
-                ra   = m.group(2)
-                rb   = m.group(3)
+                ra = m.group(2)
+                rb = m.group(3)
                 oper = m.group(4)
-                imm  = m.group(5)
-            
+                imm = m.group(5)
+
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "I-type:mathi:" + page + ":0:" + oper + ":" + ra + ":" + rb + ":0:" + imm
-        
+                progList[e]['inst_parse'] = "I-type:mathi:" + page + \
+                    ":0:" + oper + ":" + ra + ":" + rb + ":0:" + imm
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))                
-            
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # seti ch, p, $r, t
         if inst == 'seti':
-            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*,\s*\$(\d+)\s*,\s*(\-?\d+)";
+            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*,\s*\$(\d+)\s*,\s*(\-?\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
-                ch   = m.group(1)
+                ch = m.group(1)
                 page = m.group(2)
-                ra   = m.group(3)
-                t    = m.group(4)
-            
+                ra = m.group(3)
+                t = m.group(4)
+
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "I-type:seti:" + page + ":" + ch + ":0:0:" + ra + ":0:" + t
-        
+                progList[e]['inst_parse'] = "I-type:seti:" + \
+                    page + ":" + ch + ":0:0:" + ra + ":0:" + t
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))         
-            
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # synci t
         if inst == 'synci':
-            comp_re = "\s*(\d+)";
+            comp_re = "\s*(\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
-                t    = m.group(1)
-            
+                t = m.group(1)
+
                 # Add entry into structure.
                 progList[e]['inst_parse'] = "I-type:synci:0:0:0:0:0:0:" + t
-        
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))      
-            
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # waiti ch, t
         if inst == 'waiti':
-            comp_re = "\s*(\d+)\s*,\s*(\d+)";
+            comp_re = "\s*(\d+)\s*,\s*(\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
-                ch   = m.group(1)
-                t    = m.group(2)
-            
+                ch = m.group(1)
+                t = m.group(2)
+
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "I-type:waiti:0:" + ch + ":0:0:0:0:" + t
-        
+                progList[e]['inst_parse'] = "I-type:waiti:0:" + \
+                    ch + ":0:0:0:0:" + t
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))  
-                
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # bitwi p, $ra, $rb oper imm
         if inst == 'bitwi':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*([&|<>^]+)\s*(0?x?\-?[0-9a-fA-F]+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*([&|<>^]+)\s*(0?x?\-?[0-9a-fA-F]+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
                 page = m.group(1)
-                ra   = m.group(2)
-                rb   = m.group(3)
+                ra = m.group(2)
+                rb = m.group(3)
                 oper = m.group(4)
-                imm  = m.group(5)
-            
+                imm = m.group(5)
+
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "I-type:bitwi:" + page + ":0:" + oper + ":" + ra + ":" + rb + ":0:" + imm
-        
+                progList[e]['inst_parse'] = "I-type:bitwi:" + page + \
+                    ":0:" + oper + ":" + ra + ":" + rb + ":0:" + imm
+
             # bitwi p, $ra, ~imm
-            else:                         
-                comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*~\s*(0?x?\-?[0-9a-fA-F]+)";
+            else:
+                comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*~\s*(0?x?\-?[0-9a-fA-F]+)"
                 m = re.search(comp_re, args)
-        
+
                 # If there is a match.
                 if m:
                     page = m.group(1)
-                    ra   = m.group(2)
+                    ra = m.group(2)
                     oper = "~"
-                    imm  = m.group(3)
-            
+                    imm = m.group(3)
+
                     # Add entry into structure.
-                    progList[e]['inst_parse'] = "I-type:bitwi:" + page + ":0:" + oper + ":" + ra + ":0:0:" + imm
-        
+                    progList[e]['inst_parse'] = "I-type:bitwi:" + \
+                        page + ":0:" + oper + ":" + ra + ":0:0:" + imm
+
                 # Error: bad instruction format.
                 else:
-                    print("Error: bad format on instruction @%d: %s" %(e,inst))              
+                    print("Error: bad format on instruction @%d: %s" % (e, inst))
 
         # memri p, $r, imm
         if inst == 'memri':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*(0?x?\-?[0-9a-fA-F]+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*(0?x?\-?[0-9a-fA-F]+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
                 page = m.group(1)
-                r    = m.group(2)
-                imm  = m.group(3)
-            
+                r = m.group(2)
+                imm = m.group(3)
+
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "I-type:memri:" + page + ":0:0:" + r + ":0:0:" + imm
-        
+                progList[e]['inst_parse'] = "I-type:memri:" + \
+                    page + ":0:0:" + r + ":0:0:" + imm
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))        
-                
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # memwi p, $r, imm
         if inst == 'memwi':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*(0?x?\-?[0-9a-fA-F]+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*(0?x?\-?[0-9a-fA-F]+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
                 page = m.group(1)
-                r    = m.group(2)
-                imm  = m.group(3)
-            
+                r = m.group(2)
+                imm = m.group(3)
+
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "I-type:memwi:" + page + ":0:0:0:0:" + r + ":" + imm
-        
+                progList[e]['inst_parse'] = "I-type:memwi:" + \
+                    page + ":0:0:0:0:" + r + ":" + imm
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))                  
-            
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # regwi p, $r, imm
         if inst == 'regwi':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*(0?x?\-?[0-9a-fA-F]+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*(0?x?\-?[0-9a-fA-F]+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
                 page = m.group(1)
-                r    = m.group(2)
-                imm  = m.group(3)
-            
+                r = m.group(2)
+                imm = m.group(3)
+
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "I-type:regwi:" + page + ":0:0:" + r + ":0:0:" + imm
-        
+                progList[e]['inst_parse'] = "I-type:regwi:" + \
+                    page + ":0:0:" + r + ":0:0:" + imm
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))   
-                
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # setbi ch, p, $r, t
         if inst == 'setbi':
-            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*,\s*\$(\d+)\s*,\s*(\-?\d+)";
+            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*,\s*\$(\d+)\s*,\s*(\-?\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
-                ch   = m.group(1)
+                ch = m.group(1)
                 page = m.group(2)
-                ra   = m.group(3)
-                t    = m.group(4)
-            
+                ra = m.group(3)
+                t = m.group(4)
+
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "I-type:setbi:" + page + ":" + ch + ":0:0:" + ra + ":0:" + t
-        
+                progList[e]['inst_parse'] = "I-type:setbi:" + \
+                    page + ":" + ch + ":0:0:" + ra + ":0:" + t
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))                   
-                
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # J-type: three registers and an address for jump.
-        # J-type:<inst>:page:oper:ra:rb:rc:addr                
-                
+        # J-type:<inst>:page:oper:ra:rb:rc:addr
+
         # loopnz p, $r, @label
         if inst == 'loopnz':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\@(.+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\@(.+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
-                page  = m.group(1)
-                oper  = "+"
-                r     = m.group(2)
+                page = m.group(1)
+                oper = "+"
+                r = m.group(2)
                 label = m.group(3)
 
                 # Resolve symbol.
                 if label in symbList:
                     label_addr = symbList[label]
                 else:
-                    print("Error: could not resolve symbol %s on instruction @%d: %s %s" %(label,e,inst,args))
-            
+                    print("Error: could not resolve symbol %s on instruction @%d: %s %s" % (
+                        label, e, inst, args))
+
                 # Add entry into structure.
                 regs = r + ":" + r + ":0:" + str(label_addr)
-                progList[e]['inst_parse'] = "J-type:loopnz:" + page + ":" + oper + ":" + regs
-        
+                progList[e]['inst_parse'] = "J-type:loopnz:" + \
+                    page + ":" + oper + ":" + regs
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))    
-                
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # condj p, $ra op $rb, @label
         if inst == 'condj':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*([<>=!]+)\s*\$(\d+)\s*,\s*\@(.+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*([<>=!]+)\s*\$(\d+)\s*,\s*\@(.+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
-                page  = m.group(1)
-                ra    = m.group(2)
-                oper  = m.group(3)
-                rb    = m.group(4)
+                page = m.group(1)
+                ra = m.group(2)
+                oper = m.group(3)
+                rb = m.group(4)
                 label = m.group(5)
 
                 # Resolve symbol.
                 if label in symbList:
                     label_addr = symbList[label]
                 else:
-                    print("Error: could not resolve symbol %s on instruction @%d: %s %s" %(label,e,inst,args))
-            
+                    print("Error: could not resolve symbol %s on instruction @%d: %s %s" % (
+                        label, e, inst, args))
+
                 # Add entry into structure.
                 regs = ra + ":" + rb + ":" + str(label_addr)
-                progList[e]['inst_parse'] = "J-type:condj:" + page + ":" + oper + ":0:" + regs
-        
+                progList[e]['inst_parse'] = "J-type:condj:" + \
+                    page + ":" + oper + ":0:" + regs
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))                 
-            
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # end
-        if inst == 'end':       
+        if inst == 'end':
             # Add entry into structure.
             progList[e]['inst_parse'] = "J-type:end:0:0:0:0:0:0"
-        
-        
+
         # R-type: 8 registers, 7 for reading and 1 for writing.
-        # R-type:<inst>:page:channel:oper:ra:rb:rc:rd:re:rf:rg:rh            
-        
+        # R-type:<inst>:page:channel:oper:ra:rb:rc:rd:re:rf:rg:rh
+
         # math p, $ra, $rb oper $rc
         if inst == 'math':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*([\+\-\*])\s*\$(\d+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*([\+\-\*])\s*\$(\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
                 page = m.group(1)
-                ra   = m.group(2)
-                rb   = m.group(3)
+                ra = m.group(2)
+                rb = m.group(3)
                 oper = m.group(4)
-                rc   = m.group(5)
-            
+                rc = m.group(5)
+
                 # Add entry into structure.
                 regs = ra + ":" + rb + ":" + rc + ":0:0:0:0:0"
-                progList[e]['inst_parse'] = "R-type:math:" + page + ":0:" + oper + ":" + regs
-        
+                progList[e]['inst_parse'] = "R-type:math:" + \
+                    page + ":0:" + oper + ":" + regs
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))       
-            
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # set ch, p, $ra, $rb, $rc, $rd, $re, $rt
         if inst == 'set':
             regs = "\s*\$(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)"
-            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*," + regs;
+            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*," + regs
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
-                ch   = m.group(1)
+                ch = m.group(1)
                 page = m.group(2)
-                ra   = m.group(3)
-                rb   = m.group(4)
-                rc   = m.group(5)
-                rd   = m.group(6)
-                ree  = m.group(7)
-                rt   = m.group(8)
-            
+                ra = m.group(3)
+                rb = m.group(4)
+                rc = m.group(5)
+                rd = m.group(6)
+                ree = m.group(7)
+                rt = m.group(8)
+
                 # Add entry into structure.
                 regs = ra + ":" + rt + ":" + rb + ":" + rc + ":" + rd + ":" + ree + ":0"
-                progList[e]['inst_parse'] = "R-type:set:" + page + ":" + ch + ":0:0:" + regs
-        
+                progList[e]['inst_parse'] = "R-type:set:" + \
+                    page + ":" + ch + ":0:0:" + regs
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))  
-            
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # sync p, $r
         if inst == 'sync':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
                 page = m.group(1)
-                r    = m.group(2)
-            
+                r = m.group(2)
+
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "R-type:sync:" + page + ":0:0:0:0:" + r + ":0:0:0:0:0"
-        
+                progList[e]['inst_parse'] = "R-type:sync:" + \
+                    page + ":0:0:0:0:" + r + ":0:0:0:0:0"
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))    
-            
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # read ch, p, oper $r
         if inst == 'read':
-            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*,\s*(upper|lower)\s+\$(\d+)";
+            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*,\s*(upper|lower)\s+\$(\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
-                ch   = m.group(1)
+                ch = m.group(1)
                 page = m.group(2)
                 oper = m.group(3)
-                r    = m.group(4)
-            
+                r = m.group(4)
+
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "R-type:read:" + page + ":" + ch + ":" + oper + ":" + r + ":0:0:0:0:0:0:0"
-        
+                progList[e]['inst_parse'] = "R-type:read:" + page + \
+                    ":" + ch + ":" + oper + ":" + r + ":0:0:0:0:0:0:0"
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))    
-            
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # wait ch, p, $r
         if inst == 'wait':
-            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*,\s*\$(\d+)";
+            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*,\s*\$(\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
-                ch   = m.group(1)
+                ch = m.group(1)
                 page = m.group(2)
-                r    = m.group(3)
-            
+                r = m.group(3)
+
                 # Add entry into structure.
-                progList[e]['inst_parse'] = "R-type:wait:" + page + ":" + ch + ":0:0:0:" + r + ":0:0:0:0:0"
-        
+                progList[e]['inst_parse'] = "R-type:wait:" + \
+                    page + ":" + ch + ":0:0:0:" + r + ":0:0:0:0:0"
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))        
-                
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # bitw p, $ra, $rb oper $rc
         if inst == 'bitw':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*([&|<>^]+)\s*\$(\d+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*([&|<>^]+)\s*\$(\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
                 page = m.group(1)
-                ra   = m.group(2)
-                rb   = m.group(3)
+                ra = m.group(2)
+                rb = m.group(3)
                 oper = m.group(4)
-                rc   = m.group(5)
-            
+                rc = m.group(5)
+
                 # Add entry into structure.
                 regs = ra + ":" + rb + ":" + rc + ":0:0:0:0:0"
-                progList[e]['inst_parse'] = "R-type:bitw:" + page + ":0:" + oper + ":" + regs
-        
+                progList[e]['inst_parse'] = "R-type:bitw:" + \
+                    page + ":0:" + oper + ":" + regs
+
             # bitw p, $ra, ~$rb
-            else:                              
-                comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*~\s*\$(\d+)";
+            else:
+                comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*~\s*\$(\d+)"
                 m = re.search(comp_re, args)
-        
+
                 # If there is a match.
                 if m:
                     page = m.group(1)
-                    ra   = m.group(2)
-                    rb   = m.group(3)
+                    ra = m.group(2)
+                    rb = m.group(3)
                     oper = "~"
-            
+
                     # Add entry into structure.
                     regs = ra + ":0:" + ":" + rb + ":0:0:0:0:0"
-                    progList[e]['inst_parse'] = "R-type:bitw:" + page + ":0:" + oper + ":" + regs
-        
+                    progList[e]['inst_parse'] = "R-type:bitw:" + \
+                        page + ":0:" + oper + ":" + regs
+
                 # Error: bad instruction format.
                 else:
-                    print("Error: bad format on instruction @%d: %s" %(e,inst))                 
-                
+                    print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # memr p, $ra, $rb
         if inst == 'memr':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
                 page = m.group(1)
-                ra   = m.group(2)
-                rb   = m.group(3)
-            
+                ra = m.group(2)
+                rb = m.group(3)
+
                 # Add entry into structure.
                 regs = ra + ":" + rb + ":0:0:0:0:0:0"
-                progList[e]['inst_parse'] = "R-type:memr:" + page + ":0:0:" + regs
-        
+                progList[e]['inst_parse'] = "R-type:memr:" + \
+                    page + ":0:0:" + regs
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst)) 
-                
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # memw p, $ra, $rb
         if inst == 'memw':
-            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)";
+            comp_re = "\s*(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)"
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
                 page = m.group(1)
-                ra   = m.group(2)
-                rb   = m.group(3)
-            
+                ra = m.group(2)
+                rb = m.group(3)
+
                 # Add entry into structure.
                 regs = rb + ":" + ra + ":0:0:0:0:0"
-                progList[e]['inst_parse'] = "R-type:memw:" + page + ":0:0:0:" + regs
-        
+                progList[e]['inst_parse'] = "R-type:memw:" + \
+                    page + ":0:0:0:" + regs
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))                 
-                
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
         # setb ch, p, $ra, $rb, $rc, $rd, $re, $rt
         if inst == 'setb':
             regs = "\s*\$(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)\s*,\s*\$(\d+)"
-            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*," + regs;
+            comp_re = "\s*(\d+)\s*,\s*(\d+)\s*," + regs
             m = re.search(comp_re, args)
-        
+
             # If there is a match.
             if m:
-                ch   = m.group(1)
+                ch = m.group(1)
                 page = m.group(2)
-                ra   = m.group(3)
-                rb   = m.group(4)
-                rc   = m.group(5)
-                rd   = m.group(6)
-                ree  = m.group(7)
-                rt   = m.group(8)
-            
+                ra = m.group(3)
+                rb = m.group(4)
+                rc = m.group(5)
+                rd = m.group(6)
+                ree = m.group(7)
+                rt = m.group(8)
+
                 # Add entry into structure.
                 regs = ra + ":" + rt + ":" + rb + ":" + rc + ":" + rd + ":" + ree + ":0"
-                progList[e]['inst_parse'] = "R-type:setb:" + page + ":" + ch + ":0:0:" + regs
-        
+                progList[e]['inst_parse'] = "R-type:setb:" + \
+                    page + ":" + ch + ":0:0:" + regs
+
             # Error: bad instruction format.
             else:
-                print("Error: bad format on instruction @%d: %s" %(e,inst))                  
-    
+                print("Error: bad format on instruction @%d: %s" % (e, inst))
+
     ######################################
     ### Second pass: convert to binary ###
     ######################################
     for e in progList:
         inst = progList[e]['inst_parse']
         spl = inst.split(":")
-    
+
         # I-type
         if spl[0] == "I-type":
             # Instruction.
-            if spl[1] in instList:            
+            if spl[1] in instList:
                 inst_bin = instList[spl[1]]['bin']
             else:
-                print("Error: instruction %s not found on instraction list" % spl[1])
-            
+                print(
+                    "Error: instruction %s not found on instraction list" % spl[1])
+
             # page.
-            page = unsigned2bin(spl[2],3)
-            
+            page = unsigned2bin(spl[2], 3)
+
             # channel
-            ch = unsigned2bin(spl[3],3)
-            
+            ch = unsigned2bin(spl[3], 3)
+
             # oper
             oper = op2bin(spl[4])
-        
+
             # Registers.
-            ra   = unsigned2bin(spl[5],5)
-            rb   = unsigned2bin(spl[6],5)
-            rc   = unsigned2bin(spl[7],5)
-        
+            ra = unsigned2bin(spl[5], 5)
+            rb = unsigned2bin(spl[6], 5)
+            rc = unsigned2bin(spl[7], 5)
+
             # Immediate.
-            imm  = integer2bin(spl[8],31)
-        
+            imm = integer2bin(spl[8], 31)
+
             # Machine code (bin/hex).
             code = inst_bin + page + ch + oper + ra + rb + rc + imm
-            code_h = "{:016x}".format(int(code,2))
-        
+            code_h = "{:016x}".format(int(code, 2))
+
             # Write values back into hash.
             progList[e]['inst_bin'] = code
             progList[e]['inst_hex'] = code_h
-        
+
         elif (spl[0] == "J-type"):
             # Instruction.
-            if spl[1] in instList:            
+            if spl[1] in instList:
                 inst_bin = instList[spl[1]]['bin']
             else:
-                print("Error: instruction %s not found on instraction list" % spl[1])  
-            
+                print(
+                    "Error: instruction %s not found on instraction list" % spl[1])
+
             # Page.
-            page = unsigned2bin(spl[2],3)
-            
+            page = unsigned2bin(spl[2], 3)
+
             # Zeros.
-            z3 = unsigned2bin("0",3)
-            
-            #oper
+            z3 = unsigned2bin("0", 3)
+
+            # oper
             oper = op2bin(spl[3])
-        
+
             # Registers.
-            ra = unsigned2bin(spl[4],5)
-            rb = unsigned2bin(spl[5],5)
-            rc = unsigned2bin(spl[6],5)
-            
+            ra = unsigned2bin(spl[4], 5)
+            rb = unsigned2bin(spl[5], 5)
+            rc = unsigned2bin(spl[6], 5)
+
             # Zeros.
-            z15 = unsigned2bin("0",15)
-        
+            z15 = unsigned2bin("0", 15)
+
             # Address.
-            jmp_addr = unsigned2bin(spl[7],16)
-        
+            jmp_addr = unsigned2bin(spl[7], 16)
+
             # Machine code (bin/hex).
             code = inst_bin + page + z3 + oper + ra + rb + rc + z15 + jmp_addr
-            code_h = "{:016x}".format(int(code,2))
-        
+            code_h = "{:016x}".format(int(code, 2))
+
             # Write values back into hash.
             progList[e]['inst_bin'] = code
-            progList[e]['inst_hex'] = code_h 
-              
+            progList[e]['inst_hex'] = code_h
+
         elif (spl[0] == "R-type"):
             # Instruction.
-            if spl[1] in instList:            
+            if spl[1] in instList:
                 inst_bin = instList[spl[1]]['bin']
             else:
-                print("Error: instruction \"%s\" not found on instraction list" % spl[1])        
-        
+                print(
+                    "Error: instruction \"%s\" not found on instraction list" % spl[1])
+
             # Page.
-            page = unsigned2bin(spl[2],3)
-            
+            page = unsigned2bin(spl[2], 3)
+
             # Channel
-            ch = unsigned2bin(spl[3],3)
-            
+            ch = unsigned2bin(spl[3], 3)
+
             # Oper
             oper = op2bin(spl[4])
-        
+
             # Registers.
-            ra   = unsigned2bin(spl[5],5)
-            rb   = unsigned2bin(spl[6],5)
-            rc   = unsigned2bin(spl[7],5)
-            rd   = unsigned2bin(spl[8],5)
-            ree   = unsigned2bin(spl[9],5)  
-            rf   = unsigned2bin(spl[10],5)
-            rg   = unsigned2bin(spl[11],5)
-            rh   = unsigned2bin(spl[12],5)            
-            
+            ra = unsigned2bin(spl[5], 5)
+            rb = unsigned2bin(spl[6], 5)
+            rc = unsigned2bin(spl[7], 5)
+            rd = unsigned2bin(spl[8], 5)
+            ree = unsigned2bin(spl[9], 5)
+            rf = unsigned2bin(spl[10], 5)
+            rg = unsigned2bin(spl[11], 5)
+            rh = unsigned2bin(spl[12], 5)
+
             # Zeros.
-            z6 = unsigned2bin("0",6)
-        
+            z6 = unsigned2bin("0", 6)
+
             # Machine code (bin/hex).
-            code = inst_bin + page + ch + oper + ra + rb + rc + rd + ree + rf + rg + rh + z6
-            code_h = "{:016x}".format(int(code,2))
-        
+            code = inst_bin + page + ch + oper + ra + \
+                rb + rc + rd + ree + rf + rg + rh + z6
+            code_h = "{:016x}".format(int(code, 2))
+
             # Write values back into hash.
             progList[e]['inst_bin'] = code
-            progList[e]['inst_hex'] = code_h            
-        
+            progList[e]['inst_hex'] = code_h
+
         else:
-            print("Error: bad type on instruction @%d: %s" %(e,inst))
-            
+            print("Error: bad type on instruction @%d: %s" % (e, inst))
+
     ####################
     ### Write output ###
     ####################
@@ -835,18 +864,20 @@ def parse_prog(file="prog.asm",outfmt="bin"):
     if outfmt == "bin":
         for e in progList:
             outProg[e] = progList[e]['inst_bin']
-            
+
     # Hex format.
     elif outfmt == "hex":
         for e in progList:
-            out = progList[e]['inst_hex'] + " -> " + progList[e]['inst'] + " " + progList[e]['args']
+            out = progList[e]['inst_hex'] + " -> " + \
+                progList[e]['inst'] + " " + progList[e]['args']
             outProg[e] = out
-    
+
     else:
         print("Error: \"%s\" is not a recognized output format" % outfmt)
-    
+
     # Return program list.
     return outProg
+
 
 def parse_to_bin(path):
     """
@@ -858,4 +889,4 @@ def parse_to_bin(path):
     :rtype: list
     """
     p = parse_prog(path)
-    return [int(p[i],2) for i in p]
+    return [int(p[i], 2) for i in p]

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -17,12 +17,13 @@ from .qick_asm import QickConfig
 from .helpers import trace_net, get_fclk, BusParser
 from . import bitfile_path
 
+
 class SocIp(DefaultIP):
     """
     SocIp class
     """
-    REGISTERS = {}    
-    
+    REGISTERS = {}
+
     def __init__(self, description, **kwargs):
         """
         Constructor method
@@ -32,7 +33,7 @@ class SocIp(DefaultIP):
         self.fullpath = description['fullpath']
         self.type = description['type'].split(':')[-2]
         #self.ip = description
-        
+
     def write(self, offset, value):
         """
         Writes a value to a register specified by an offset
@@ -43,7 +44,7 @@ class SocIp(DefaultIP):
         :type value: int
         """
         super().write(offset, value)
-        
+
     def read(self, offset):
         """
         Reads an offset
@@ -52,8 +53,8 @@ class SocIp(DefaultIP):
         :type offset: int
         """
         return super().read(offset)
-    
-    def __setattr__(self, a ,v):
+
+    def __setattr__(self, a, v):
         """
         Sets the arguments associated with a register
 
@@ -67,8 +68,8 @@ class SocIp(DefaultIP):
         if a in self.__class__.REGISTERS:
             super().write(4*self.__class__.REGISTERS[a], int(v))
         else:
-            return super().__setattr__(a,v)
-    
+            return super().__setattr__(a, v)
+
     def __getattr__(self, a):
         """
         Gets the arguments associated with a register
@@ -81,12 +82,14 @@ class SocIp(DefaultIP):
         if a in self.__class__.REGISTERS:
             return super().read(4*self.__class__.REGISTERS[a])
         else:
-            return super().__getattribute__(a)           
-        
+            return super().__getattribute__(a)
+
+
 class AbsSignalGen(SocIp):
     """
     Abstract class which defines methods that are common to different signal generators.
     """
+
     def __init__(self, description, **kwargs):
         """
         Constructor method
@@ -100,41 +103,41 @@ class AbsSignalGen(SocIp):
 
         # dma
         self.dma = axi_dma
-        
+
         # Switch
         self.switch = axis_switch
 
         # Sampling frequency.
-        self.fs = fs   
+        self.fs = fs
 
     def configure_connections(self, soc, sigparser, busparser):
         # what tProc output port drives this generator?
         # we will eventually also use this to find out which tProc drives this gen, for multi-tProc firmwares
-        ((block,port),) = trace_net(busparser, self.fullpath, 's1_axis')
+        ((block, port),) = trace_net(busparser, self.fullpath, 's1_axis')
         # might need to jump through an axis_clk_cnvrt
         if 'axis_tproc' not in block:
-            ((block,port),) = trace_net(busparser, block, 'S_AXIS')
+            ((block, port),) = trace_net(busparser, block, 'S_AXIS')
         # port names are of the form 'm2_axis_tdata'
         # subtract 1 to get the output channel number (m0 goes to the DMA)
         self.tproc_ch = int(port.split('_')[0][1:])-1
 
         # what switch port drives this generator?
-        ((block,port),) = trace_net(busparser, self.fullpath, 's0_axis')
+        ((block, port),) = trace_net(busparser, self.fullpath, 's0_axis')
         # port names are of the form 'M01_AXIS'
         self.switch_ch = int(port.split('_')[0][1:])
 
         # what RFDC port does this generator drive?
-        ((block,port),) = trace_net(busparser, self.fullpath, 'm_axis')
+        ((block, port),) = trace_net(busparser, self.fullpath, 'm_axis')
         # might need to jump through an axis_register_slice
         if 'rf_data_converter' not in block:
-            ((block,port),) = trace_net(busparser, block, 'M_AXIS')
+            ((block, port),) = trace_net(busparser, block, 'M_AXIS')
         # port names are of the form 's00_axis'
         self.dac = port[1:3]
 
         #print("%s: switch %d, tProc ch %d, DAC tile %s block %s"%(self.fullpath, self.switch_ch, self.tproc_ch, *self.dac))
 
     # Load waveforms.
-    def load(self, xin_i, xin_q ,addr=0):
+    def load(self, xin_i, xin_q, addr=0):
         """
         Load waveform into I,Q envelope
 
@@ -147,40 +150,44 @@ class AbsSignalGen(SocIp):
         """
         # Check for equal length.
         if len(xin_i) != len(xin_q):
-            print("%s: I/Q buffers must be the same length." % self.__class__.__name__)
+            print("%s: I/Q buffers must be the same length." %
+                  self.__class__.__name__)
             return
-        
+
         # Check for max length.
         if len(xin_i) > self.MAX_LENGTH:
-            print("%s: buffer length must be %d samples or less." % (self.__class__.__name__,self.MAX_LENGTH))
+            print("%s: buffer length must be %d samples or less." %
+                  (self.__class__.__name__, self.MAX_LENGTH))
             return
 
         # Check for even transfer size.
-        if len(xin_i) %2 != 0:
+        if len(xin_i) % 2 != 0:
             raise RuntimeError("Buffer transfer length must be even number.")
 
         # Check for max length.
         if np.max(xin_i) > np.iinfo(np.int16).max or np.min(xin_i) < np.iinfo(np.int16).min:
-            raise ValueError("real part of envelope exceeds limits of int16 datatype")
+            raise ValueError(
+                "real part of envelope exceeds limits of int16 datatype")
 
         if np.max(xin_q) > np.iinfo(np.int16).max or np.min(xin_q) < np.iinfo(np.int16).min:
-            raise ValueError("imaginary part of envelope exceeds limits of int16 datatype")
+            raise ValueError(
+                "imaginary part of envelope exceeds limits of int16 datatype")
 
         # Route switch to channel.
         self.switch.sel(mst=self.switch_ch)
-        
-        #time.sleep(0.050)
-        
+
+        # time.sleep(0.050)
+
         # Format data.
         xin_i = xin_i.astype(np.int32)
         xin_q = xin_q.astype(np.int32)
 
         xin = xin_i + (xin_q << 16)
-        
+
         # Define buffer.
         self.buff = allocate(shape=len(xin), dtype=np.int32)
         np.copyto(self.buff, xin)
-        
+
         ################
         ### Load I/Q ###
         ################
@@ -192,21 +199,22 @@ class AbsSignalGen(SocIp):
         self.dma.sendchannel.wait()
 
         # Disable writes.
-        self.wr_disable()        
-        
-    def wr_enable(self,addr=0):
+        self.wr_disable()
+
+    def wr_enable(self, addr=0):
         """
            Enable WE reg
         """
         self.start_addr_reg = addr
         self.we_reg = 1
-        
+
     def wr_disable(self):
         """
            Disable WE reg
         """
         self.we_reg = 0
-        
+
+
 class AxisSignalGen(AbsSignalGen):
     """
     AxisSignalGen class
@@ -219,18 +227,19 @@ class AxisSignalGen(AbsSignalGen):
     * 0 : disable writes.
     * 1 : enable writes.
     """
-    bindto = ['user.org:user:axis_signal_gen_v4:1.0', 'user.org:user:axis_signal_gen_v5:1.0']
-    REGISTERS = {'start_addr_reg':0, 'we_reg':1, 'rndq_reg':2}
-    
+    bindto = ['user.org:user:axis_signal_gen_v4:1.0',
+              'user.org:user:axis_signal_gen_v5:1.0']
+    REGISTERS = {'start_addr_reg': 0, 'we_reg': 1, 'rndq_reg': 2}
+
     def __init__(self, description, **kwargs):
         """
         Constructor method
         """
         super().__init__(description)
-        
+
         # Default registers.
-        self.start_addr_reg=0
-        self.we_reg=0
+        self.start_addr_reg = 0
+        self.we_reg = 0
         self.rndq_reg = 10
 
         # Generics
@@ -248,7 +257,8 @@ class AxisSignalGen(AbsSignalGen):
            TODO: remove this function. This functionality was removed from IP block.
         """
         self.rndq_reg = sel_
-                
+
+
 class AxisSgInt4V1(AbsSignalGen):
     """
     AxisSgInt4V1
@@ -261,37 +271,39 @@ class AxisSgInt4V1(AbsSignalGen):
     * 1 : enable writes.
     """
     bindto = ['user.org:user:axis_sg_int4_v1:1.0']
-    REGISTERS = {'start_addr_reg':0, 'we_reg':1}
-    
+    REGISTERS = {'start_addr_reg': 0, 'we_reg': 1}
+
     def __init__(self, description, **kwargs):
         """
         Constructor method
         """
         super().__init__(description)
-        
+
         # Default registers.
-        self.start_addr_reg=0
-        self.we_reg=0
+        self.start_addr_reg = 0
+        self.we_reg = 0
 
         # Generics
         self.N = int(description['parameters']['N'])
-        self.NDDS = 4 # Fixed by design, not accesible.
-                
+        self.NDDS = 4  # Fixed by design, not accesible.
+
         # Frequency resolution
-        self.B_DDS = 16      
+        self.B_DDS = 16
 
         # Maximum number of samples
-        self.MAX_LENGTH = 2**self.N # Table is interpolated. Length is given only by parameter N.
+        # Table is interpolated. Length is given only by parameter N.
+        self.MAX_LENGTH = 2**self.N
 
-        ## Get the channel number from the IP instance name.
+        # Get the channel number from the IP instance name.
         #self.ch = int(description['fullpath'].split('_')[-1])
-        
+
+
 class AxisSgMux4V1(AbsSignalGen):
     """
     AxisSgMux4V1
 
     AXIS Signal Generator with 4 muxed outputs V1 registers.
-    
+
     PINC0_REG : frequency of waveform 0.
     PINC1_REG : frequency of waveform 1.
     PINC2_REG : frequency of waveform 2.
@@ -302,31 +314,32 @@ class AxisSgMux4V1(AbsSignalGen):
     * 1 : enable writes.
     """
     bindto = ['user.org:user:axis_sg_mux4_v1:1.0']
-    REGISTERS = {'pinc0_reg':0,'pinc1_reg':1,'pinc2_reg':2,'pinc3_reg':3, 'we_reg':4}
-    
+    REGISTERS = {'pinc0_reg': 0, 'pinc1_reg': 1,
+                 'pinc2_reg': 2, 'pinc3_reg': 3, 'we_reg': 4}
+
     def __init__(self, description, **kwargs):
         """
         Constructor method
         """
         super().__init__(description)
-        
+
         # Default registers.
-        self.pinc0_reg=0
-        self.pinc1_reg=0
-        self.pinc2_reg=0
-        self.pinc3_reg=0
-        self.we_reg=0
+        self.pinc0_reg = 0
+        self.pinc1_reg = 0
+        self.pinc2_reg = 0
+        self.pinc3_reg = 0
+        self.we_reg = 0
 
         # Generics
-        self.NDDS = int(description['parameters']['N_DDS'])        
-                
+        self.NDDS = int(description['parameters']['N_DDS'])
+
         # Frequency resolution
-        self.B_DDS = 16      
+        self.B_DDS = 16
 
         # dummy values, since this doesn't have a waveform memory.
         self.switch_ch = -1
         self.MAX_LENGTH = 0
-        
+
     # Configure this driver with links to the other drivers, and the signal gen channel number.
     def configure(self, ch, axi_dma, axis_switch, fs):
         # Channel number corresponding to entry in the QickConfig list of gens.
@@ -334,24 +347,24 @@ class AxisSgMux4V1(AbsSignalGen):
 
         # Sampling frequency: 4x Interpolation applied by DAC IP.
         self.fs = fs/4
-        
+
     def configure_connections(self, soc, sigparser, busparser):
         self.soc = soc
 
         # what tProc output port drives this generator?
         # we will eventually also use this to find out which tProc drives this gen, for multi-tProc firmwares
-        ((block,port),) = trace_net(busparser, self.fullpath, 's_axis')
+        ((block, port),) = trace_net(busparser, self.fullpath, 's_axis')
         # might need to jump through an axis_clk_cnvrt
         if 'axis_tproc' not in block:
-            ((block,port),) = trace_net(busparser, block, 'S_AXIS')
+            ((block, port),) = trace_net(busparser, block, 'S_AXIS')
         # port names are of the form 'm2_axis_tdata'
         # subtract 1 to get the output channel number (m0 goes to the DMA)
         self.tproc_ch = int(port.split('_')[0][1:])-1
 
         # what RFDC port does this generator drive?
-        ((block,port),) = trace_net(busparser, self.fullpath, 'm_axis')
+        ((block, port),) = trace_net(busparser, self.fullpath, 'm_axis')
         # port names are of the form 's00_axis'
-        self.dac = port[1:3]        
+        self.dac = port[1:3]
 
     def update(self):
         """
@@ -359,7 +372,7 @@ class AxisSgMux4V1(AbsSignalGen):
         """
         self.we_reg = 1
         self.we_reg = 0
-            
+
     def set_freq(self, f, out=0, dac_ch=0):
         """
         Set frequency register
@@ -372,45 +385,46 @@ class AxisSgMux4V1(AbsSignalGen):
         :type dac_ch: int
         """
         # Sanity check.
-        if f<self.fs:
+        if f < self.fs:
             k_i = np.int64(self.soc.freq2reg_adc(f, ro_ch=self.ch))
-        
+
     def set_freq_int(self, k_i, out=0):
         setattr(self, "pinc{0}_reg".format(out), k_i)
 
         # Register update.
-        self.update()              
-                
+        self.update()
+
+
 class AxisConstantIQ(SocIp):
     # AXIS Constant IQ registers:
     # REAL_REG : 16-bit.
     # IMAG_REG : 16-bit.
     # WE_REG   : 1-bit. Update registers.
     bindto = ['user.org:user:axis_constant_iq:1.0']
-    REGISTERS = {'real_reg':0, 'imag_reg':1, 'we_reg':2}
-    
+    REGISTERS = {'real_reg': 0, 'imag_reg': 1, 'we_reg': 2}
+
     # Number of bits.
     B = 16
     MAX_V = 2**(B-1)-1
-        
+
     def __init__(self, description):
         # Initialize ip
         super().__init__(description)
-        
+
         # Default registers.
         self.real_reg = 30000
         self.imag_reg = 30000
-        
+
         # Register update.
         self.update()
-        
+
     def configure_connections(self, soc, sigparser, busparser):
         self.soc = soc
 
         # what RFDC port does this generator drive?
-        ((block,port),) = trace_net(busparser, self.fullpath, 'm_axis')
+        ((block, port),) = trace_net(busparser, self.fullpath, 'm_axis')
         # port names are of the form 's00_axis'
-        self.dac = port[1:3]        
+        self.dac = port[1:3]
 
     def configure(self, rf, fs):
         # RFDC
@@ -419,18 +433,18 @@ class AxisConstantIQ(SocIp):
         self.fs = fs
 
     def update(self):
-        self.we_reg = 1        
+        self.we_reg = 1
         self.we_reg = 0
-        
-    def set_iq(self,i=1,q=1):
+
+    def set_iq(self, i=1, q=1):
         # Set registers.
         self.real_reg = int(i*self.MAX_V)
         self.imag_reg = int(q*self.MAX_V)
-        
-        # Register update.
-        self.update()                
 
-                                
+        # Register update.
+        self.update()
+
+
 class AxisReadoutV2(SocIp):
     """
     AxisReadoutV2 class
@@ -459,27 +473,28 @@ class AxisReadoutV2(SocIp):
     :type fs: float
     """
     bindto = ['user.org:user:axis_readout_v2:1.0']
-    REGISTERS = {'freq_reg':0, 'phase_reg':1, 'nsamp_reg':2, 'outsel_reg':3, 'mode_reg': 4, 'we_reg':5}
-    
+    REGISTERS = {'freq_reg': 0, 'phase_reg': 1, 'nsamp_reg': 2,
+                 'outsel_reg': 3, 'mode_reg': 4, 'we_reg': 5}
+
     # Bits of DDS.
     B_DDS = 32
-    
+
     def __init__(self, description, **kwargs):
         """
         Constructor method
         """
         super().__init__(description)
-        
+
         # Default registers.
         self.freq_reg = 0
         self.phase_reg = 0
         self.nsamp_reg = 10
         self.outsel_reg = 0
         self.mode_reg = 1
-        
+
         # Register update.
         self.update()
-        
+
     # Configure this driver with the sampling frequency.
     def configure(self, ch, fs):
         # Channel number corresponding to entry in the QickConfig list of readouts.
@@ -487,23 +502,23 @@ class AxisReadoutV2(SocIp):
 
         # Sampling frequency.
         self.fs = fs
-        
+
     def configure_connections(self, soc, sigparser, busparser):
         self.soc = soc
 
         # what RFDC port drives this readout?
-        ((block,port),) = trace_net(busparser, self.fullpath, 's_axis')
-         # might need to jump through an axis_register_slice
+        ((block, port),) = trace_net(busparser, self.fullpath, 's_axis')
+        # might need to jump through an axis_register_slice
         if 'rf_data_converter' not in block:
-            ((block,port),) = trace_net(busparser, block, 'S_AXIS')
+            ((block, port),) = trace_net(busparser, block, 'S_AXIS')
         # port names are of the form 'm02_axis' where the block number is always even
         iTile, iBlock = [int(x) for x in port[1:3]]
         if soc.hs_adc:
             iBlock //= 2
-        self.adc = "%d%d"%(iTile, iBlock)
+        self.adc = "%d%d" % (iTile, iBlock)
 
         # what buffer does this readout drive?
-        ((block,port),) = trace_net(busparser, self.fullpath, 'm1_axis')
+        ((block, port),) = trace_net(busparser, self.fullpath, 'm1_axis')
         self.buffer = getattr(soc, block)
 
         #print("%s: ADC tile %s block %s, buffer %s"%(self.fullpath, *self.adc, self.buffer.fullpath))
@@ -514,19 +529,19 @@ class AxisReadoutV2(SocIp):
         """
         self.we_reg = 1
         self.we_reg = 0
-        
-    def set_out(self,sel="product"):
+
+    def set_out(self, sel="product"):
         """
         Select readout signal output
 
         :param sel: select mux control
         :type sel: int
         """
-        self.outsel_reg={"product":0,"dds":1,"input":2}[sel]
-            
+        self.outsel_reg = {"product": 0, "dds": 1, "input": 2}[sel]
+
         # Register update.
         self.update()
-            
+
     def set_freq(self, f, dac_ch=0):
         """
         Set frequency register
@@ -537,12 +552,12 @@ class AxisReadoutV2(SocIp):
         :type dac_ch: int
         """
         # Sanity check.
-        if f<self.fs:
+        if f < self.fs:
             self.freq_reg = np.int64(self.soc.freq2reg_adc(f, ro_ch=self.ch))
-            
+
         # Register update.
         self.update()
-        
+
     def set_freq_int(self, f_int):
         """
         Set frequency register (integer version)
@@ -551,10 +566,11 @@ class AxisReadoutV2(SocIp):
         :type f_int: int
         """
         self.freq_reg = f_int
-            
+
         # Register update.
-        self.update()        
-        
+        self.update()
+
+
 class AxisAvgBuffer(SocIp):
     """
     AxisAvgBuffer class
@@ -606,30 +622,30 @@ class AxisAvgBuffer(SocIp):
     :type channel: int
     """
     bindto = ['user.org:user:axis_avg_buffer:1.0']
-    REGISTERS = {'avg_start_reg'    : 0, 
-                 'avg_addr_reg'     : 1,
-                 'avg_len_reg'      : 2,
-                 'avg_dr_start_reg' : 3,
-                 'avg_dr_addr_reg'  : 4,
-                 'avg_dr_len_reg'   : 5,
-                 'buf_start_reg'    : 6, 
-                 'buf_addr_reg'     : 7,
-                 'buf_len_reg'      : 8,
-                 'buf_dr_start_reg' : 9,
-                 'buf_dr_addr_reg'  : 10,
-                 'buf_dr_len_reg'   : 11}
-    
+    REGISTERS = {'avg_start_reg': 0,
+                 'avg_addr_reg': 1,
+                 'avg_len_reg': 2,
+                 'avg_dr_start_reg': 3,
+                 'avg_dr_addr_reg': 4,
+                 'avg_dr_len_reg': 5,
+                 'buf_start_reg': 6,
+                 'buf_addr_reg': 7,
+                 'buf_len_reg': 8,
+                 'buf_dr_start_reg': 9,
+                 'buf_dr_addr_reg': 10,
+                 'buf_dr_len_reg': 11}
+
     def __init__(self, description, **kwargs):
         """
         Constructor method
         """
         super().__init__(description)
-        
+
         # Default registers.
-        self.avg_start_reg    = 0
+        self.avg_start_reg = 0
         self.avg_dr_start_reg = 0
-        self.buf_start_reg    = 0
-        self.buf_dr_start_reg = 0        
+        self.buf_start_reg = 0
+        self.buf_dr_start_reg = 0
 
         # Generics
         self.B = int(description['parameters']['B'])
@@ -637,7 +653,7 @@ class AxisAvgBuffer(SocIp):
         self.N_BUF = int(description['parameters']['N_BUF'])
 
         # Maximum number of samples
-        self.AVG_MAX_LENGTH = 2**self.N_AVG  
+        self.AVG_MAX_LENGTH = 2**self.N_AVG
         self.BUF_MAX_LENGTH = 2**self.N_BUF
 
         # Preallocate memory buffers for DMA transfers.
@@ -649,45 +665,46 @@ class AxisAvgBuffer(SocIp):
         # DMAs.
         self.dma_avg = axi_dma_avg
         self.dma_buf = axi_dma_buf
-        
+
         # Switches.
         self.switch_avg = switch_avg
         self.switch_buf = switch_buf
-        
+
     def configure_connections(self, soc, sigparser, busparser):
         # which readout drives this buffer?
-        ((block,port),) = trace_net(busparser, self.fullpath, 's_axis')
+        ((block, port),) = trace_net(busparser, self.fullpath, 's_axis')
         self.readout = getattr(soc, block)
 
         # which switch_avg port does this buffer drive?
-        ((block,port),) = trace_net(busparser, self.fullpath, 'm0_axis')
+        ((block, port),) = trace_net(busparser, self.fullpath, 'm0_axis')
         # port names are of the form 'S01_AXIS'
-        switch_avg_ch = int(port.split('_')[0][1:],10)
+        switch_avg_ch = int(port.split('_')[0][1:], 10)
 
         # which switch_buf port does this buffer drive?
-        ((block,port),) = trace_net(busparser, self.fullpath, 'm1_axis')
+        ((block, port),) = trace_net(busparser, self.fullpath, 'm1_axis')
         # port names are of the form 'S01_AXIS'
-        switch_buf_ch = int(port.split('_')[0][1:],10)
-        if switch_avg_ch!=switch_buf_ch:
-            raise RuntimeError("switch_avg and switch_buf port numbers do not match:",self.fullpath)
+        switch_buf_ch = int(port.split('_')[0][1:], 10)
+        if switch_avg_ch != switch_buf_ch:
+            raise RuntimeError(
+                "switch_avg and switch_buf port numbers do not match:", self.fullpath)
         self.switch_ch = switch_avg_ch
 
         # which tProc output bit triggers this buffer?
-        ((block,port),) = trace_net(sigparser, self.fullpath, 'trigger')
+        ((block, port),) = trace_net(sigparser, self.fullpath, 'trigger')
         # port names are of the form 'dout14'
         self.trigger_bit = int(port[4:])
 
         # which tProc input port does this buffer drive?
-        ((block,port),) = trace_net(busparser, self.fullpath, 'm2_axis')
+        ((block, port),) = trace_net(busparser, self.fullpath, 'm2_axis')
         # jump through an axis_clk_cnvrt
-        ((block,port),) = trace_net(busparser, block, 'M_AXIS')
+        ((block, port),) = trace_net(busparser, block, 'M_AXIS')
         # port names are of the form 's1_axis'
         # subtract 1 to get the channel number (s0 comes from the DMA)
         self.tproc_ch = int(port.split('_')[0][1:])-1
 
         #print("%s: readout %s, switch %d, trigger %d, tProc port %d"%(self.fullpath, self.readout.fullpath, self.switch_ch, self.trigger_bit, self.tproc_ch))
 
-    def config(self,address=0,length=100):
+    def config(self, address=0, length=100):
         """
         Configure both average and raw buffers
 
@@ -697,9 +714,9 @@ class AxisAvgBuffer(SocIp):
         :type length: int
         """
         # Configure averaging and buffering to the same address and length.
-        self.config_avg(address=address,length=length)
-        self.config_buf(address=address,length=length)
-        
+        self.config_avg(address=address, length=length)
+        self.config_buf(address=address, length=length)
+
     def enable(self):
         """
         Enable both average and raw buffers
@@ -707,8 +724,8 @@ class AxisAvgBuffer(SocIp):
         # Enable both averager and buffer.
         self.enable_avg()
         self.enable_buf()
-        
-    def config_avg(self,address=0,length=100):
+
+    def config_avg(self, address=0, length=100):
         """
         Configure average buffer data from average and buffering readout block
 
@@ -719,12 +736,12 @@ class AxisAvgBuffer(SocIp):
         """
         # Disable averaging.
         self.disable_avg()
-        
+
         # Set registers.
         self.avg_addr_reg = address
         self.avg_len_reg = length
-        
-    def transfer_avg(self,address=0,length=100):
+
+    def transfer_avg(self, address=0, length=100):
         """
         Transfer average buffer data from average and buffering readout block.
 
@@ -736,28 +753,30 @@ class AxisAvgBuffer(SocIp):
         :rtype: list
         """
 
-        if length %2 != 0:
+        if length % 2 != 0:
             raise RuntimeError("Buffer transfer length must be even number.")
         if length >= self.AVG_MAX_LENGTH:
-            raise RuntimeError("length=%d longer than %d"%(length, self.AVG_MAX_LENGTH))
+            raise RuntimeError("length=%d longer than %d" %
+                               (length, self.AVG_MAX_LENGTH))
 
         # Route switch to channel.
         self.switch_avg.sel(slv=self.switch_ch)
-        
+
         # Set averager data reader address and length.
         self.avg_dr_addr_reg = address
         self.avg_dr_len_reg = length
-        
+
         # Start send data mode.
         self.avg_dr_start_reg = 1
-        
+
         # DMA data.
         buff = self.avg_buff
-        self.dma_avg.recvchannel.transfer(buff,nbytes=length*8)
+        self.dma_avg.recvchannel.transfer(buff, nbytes=length*8)
         self.dma_avg.recvchannel.wait()
 
         if self.dma_avg.recvchannel.transferred != length*8:
-            raise RuntimeError("Requested %d samples but only got %d from DMA" % (length, self.dma_avg.recvchannel.transferred//8))
+            raise RuntimeError("Requested %d samples but only got %d from DMA" % (
+                length, self.dma_avg.recvchannel.transferred//8))
 
         # Stop send data mode.
         self.avg_dr_start_reg = 0
@@ -769,21 +788,21 @@ class AxisAvgBuffer(SocIp):
         dataI = data & 0xFFFFFFFF
         dataQ = data >> 32
 
-        return np.stack((dataI,dataQ)).astype(np.int32)
-        
+        return np.stack((dataI, dataQ)).astype(np.int32)
+
     def enable_avg(self):
         """
         Enable average buffer capture
         """
         self.avg_start_reg = 1
-        
+
     def disable_avg(self):
         """
         Disable average buffer capture
         """
-        self.avg_start_reg = 0    
-        
-    def config_buf(self,address=0,length=100):
+        self.avg_start_reg = 0
+
+    def config_buf(self, address=0, length=100):
         """
         Configure raw buffer data from average and buffering readout block
 
@@ -794,12 +813,12 @@ class AxisAvgBuffer(SocIp):
         """
         # Disable buffering.
         self.disable_buf()
-        
+
         # Set registers.
         self.buf_addr_reg = address
-        self.buf_len_reg = length    
-        
-    def transfer_buf(self,address=0,length=100):
+        self.buf_len_reg = length
+
+    def transfer_buf(self, address=0, length=100):
         """
         Transfer raw buffer data from average and buffering readout block
 
@@ -811,30 +830,32 @@ class AxisAvgBuffer(SocIp):
         :rtype: list
         """
 
-        if length %2 != 0:
+        if length % 2 != 0:
             raise RuntimeError("Buffer transfer length must be even number.")
         if length >= self.BUF_MAX_LENGTH:
-            raise RuntimeError("length=%d longer or equal to %d"%(length, self.BUF_MAX_LENGTH))
+            raise RuntimeError("length=%d longer or equal to %d" %
+                               (length, self.BUF_MAX_LENGTH))
 
         # Route switch to channel.
         self.switch_buf.sel(slv=self.switch_ch)
-        
-        #time.sleep(0.050)
-        
+
+        # time.sleep(0.050)
+
         # Set buffer data reader address and length.
         self.buf_dr_addr_reg = address
         self.buf_dr_len_reg = length
-        
+
         # Start send data mode.
         self.buf_dr_start_reg = 1
-        
+
         # DMA data.
         buff = self.buf_buff
-        self.dma_buf.recvchannel.transfer(buff,nbytes=length*4)
+        self.dma_buf.recvchannel.transfer(buff, nbytes=length*4)
         self.dma_buf.recvchannel.wait()
 
         if self.dma_buf.recvchannel.transferred != length*4:
-            raise RuntimeError("Requested %d samples but only got %d from DMA" % (length, self.dma_buf.recvchannel.transferred//4))
+            raise RuntimeError("Requested %d samples but only got %d from DMA" % (
+                length, self.dma_buf.recvchannel.transferred//4))
 
         # Stop send data mode.
         self.buf_dr_start_reg = 0
@@ -846,20 +867,21 @@ class AxisAvgBuffer(SocIp):
         dataI = data & 0xFFFF
         dataQ = data >> 16
 
-        return np.stack((dataI,dataQ)).astype(np.int16)
-        
+        return np.stack((dataI, dataQ)).astype(np.int16)
+
     def enable_buf(self):
         """
         Enable raw buffer capture
         """
         self.buf_start_reg = 1
-        
+
     def disable_buf(self):
         """
         Disable raw buffer capture
         """
-        self.buf_start_reg = 0         
-        
+        self.buf_start_reg = 0
+
+
 class MrBufferEt(SocIp):
     # Registers.
     # DW_CAPTURE_REG
@@ -874,62 +896,63 @@ class MrBufferEt(SocIp):
     # DR_START_REG needs to be de-assereted and asserted again to allow a new transfer.
     #
     bindto = ['user.org:user:mr_buffer_et:1.0']
-    REGISTERS = {'dw_capture_reg':0, 'dr_start_reg':1}
-        
-    def __init__(self, description):    
+    REGISTERS = {'dw_capture_reg': 0, 'dr_start_reg': 1}
+
+    def __init__(self, description):
         # Init IP.
         super().__init__(description)
-        
+
         # Default registers.
-        self.dw_capture_reg=0
-        self.dr_start_reg=0
-        
+        self.dw_capture_reg = 0
+        self.dr_start_reg = 0
+
         # Generics
         self.B = int(description['parameters']['B'])
         self.N = int(description['parameters']['N'])
         self.NM = int(description['parameters']['NM'])
 
         # Maximum number of samples
-        self.MAX_LENGTH = 2**self.N * self.NM          
+        self.MAX_LENGTH = 2**self.N * self.NM
 
         # Preallocate memory buffers for DMA transfers.
-        self.buff = allocate(shape=self.MAX_LENGTH, dtype=np.int32)        
-    
+        self.buff = allocate(shape=self.MAX_LENGTH, dtype=np.int32)
+
     def config(self, dma, switch):
         self.dma = dma
         self.switch = switch
-        
-    def route(self,ch):
+
+    def route(self, ch):
         # Route switch to channel.
         self.switch.sel(slv=ch)
-        
+
     def transfer(self):
         # Start send data mode.
         self.dr_start_reg = 1
-        
-        # DMA data.        
+
+        # DMA data.
         buff = self.buff
         self.dma.recvchannel.transfer(buff)
-        self.dma.recvchannel.wait()        
+        self.dma.recvchannel.wait()
 
         # Stop send data mode.
         self.dr_start_reg = 0
-        
+
         # Format:
         # -> lower 16 bits: I value.
         # -> higher 16 bits: Q value.
         data = buff
         dataI = data & 0xFFFF
         dataQ = data >> 16
-        
-        return np.stack((dataI,dataQ)).astype(np.int16)        
-        
+
+        return np.stack((dataI, dataQ)).astype(np.int16)
+
     def enable(self):
         self.dw_capture_reg = 1
-        
+
     def disable(self):
         self.dw_capture_reg = 0
-        
+
+
 class AxisTProc64x32_x8(SocIp):
     """
     AxisTProc64x32_x8 class
@@ -969,22 +992,22 @@ class AxisTProc64x32_x8(SocIp):
     :type axi_dma: int
     """
     bindto = ['user.org:user:axis_tproc64x32_x8:1.0']
-    REGISTERS = {'start_src_reg' : 0, 
-                 'start_reg' : 1, 
-                 'mem_mode_reg' : 2, 
-                 'mem_start_reg' : 3, 
-                 'mem_addr_reg' : 4, 
-                 'mem_len_reg' : 5}
-    
+    REGISTERS = {'start_src_reg': 0,
+                 'start_reg': 1,
+                 'mem_mode_reg': 2,
+                 'mem_start_reg': 3,
+                 'mem_addr_reg': 4,
+                 'mem_len_reg': 5}
+
     # Reserved lower memory section for register access.
-    DMEM_OFFSET = 256 
-    
+    DMEM_OFFSET = 256
+
     def __init__(self, description):
         """
         Constructor method
         """
         super().__init__(description)
-        
+
         # Default registers.
         # start_src_reg = 0   : internal start.
         # start_reg     = 0   : stopped.
@@ -993,25 +1016,25 @@ class AxisTProc64x32_x8(SocIp):
         # mem_addr_reg  = 0   : start address = 0.
         # mem_len_reg   = 100 : default length.
         self.start_src_reg = 0
-        self.start_reg     = 0
-        self.mem_mode_reg  = 0
+        self.start_reg = 0
+        self.mem_mode_reg = 0
         self.mem_start_reg = 0
-        self.mem_addr_reg  = 0
-        self.mem_len_reg   = 100
+        self.mem_addr_reg = 0
+        self.mem_len_reg = 100
 
         # Generics.
         self.DMEM_N = int(description['parameters']['DMEM_N'])
         self.PMEM_N = int(description['parameters']['PMEM_N'])
-        
+
     # Configure this driver with links to its memory and DMA.
     def configure(self, mem, axi_dma):
         # Program memory.
         self.mem = mem
 
         # dma
-        self.dma = axi_dma 
+        self.dma = axi_dma
 
-    def start_src(self,src=0):
+    def start_src(self, src=0):
         """
         Sets the start source of tProc
 
@@ -1019,27 +1042,27 @@ class AxisTProc64x32_x8(SocIp):
         :type src: int
         """
         self.start_src_reg = src
-        
+
     def start(self):
         """
         Start tProc from register
         """
         self.start_reg = 1
-        
+
     def stop(self):
         """
         Stop tProc from register
         """
         self.start_reg = 0
-        
+
     def load_bin_program(self, binprog):
-        for ii,inst in enumerate(binprog):
+        for ii, inst in enumerate(binprog):
             dec_low = inst & 0xffffffff
             dec_high = inst >> 32
             self.mem.write(8*ii, value=int(dec_low))
             self.mem.write(4*(2*ii+1), value=int(dec_high))
-        
-    def load_qick_program(self, prog, debug= False):
+
+    def load_qick_program(self, prog, debug=False):
         """
         :param prog: the QickProgram to load
         :type prog: str
@@ -1047,8 +1070,8 @@ class AxisTProc64x32_x8(SocIp):
         :type debug: bool
         """
         self.load_bin_program(prog.compile(debug=debug))
-        
-    def load_program(self,prog="prog.asm",fmt="asm"):
+
+    def load_program(self, prog="prog.asm", fmt="asm"):
         """
         Loads tProc program. If asm progam, it compiles first
 
@@ -1060,36 +1083,36 @@ class AxisTProc64x32_x8(SocIp):
         # Binary file format.
         if fmt == "bin":
             # Read binary file from disk.
-            fd = open(prog,"r")
-            
+            fd = open(prog, "r")
+
             # Write memory.
             addr = 0
             for line in fd:
                 line.strip("\r\n")
-                dec = int(line,2)
+                dec = int(line, 2)
                 dec_low = dec & 0xffffffff
                 dec_high = dec >> 32
-                self.mem.write(addr,value=int(dec_low))
+                self.mem.write(addr, value=int(dec_low))
                 addr = addr + 4
-                self.mem.write(addr,value=int(dec_high))
-                addr = addr + 4                
-                
+                self.mem.write(addr, value=int(dec_high))
+                addr = addr + 4
+
         # Asm file.
         elif fmt == "asm":
             # Compile program.
             progList = parse_to_bin(prog)
-        
+
             # Load Program Memory.
             addr = 0
             for dec in progList:
                 #print ("@" + str(addr) + ": " + str(dec))
                 dec_low = dec & 0xffffffff
                 dec_high = dec >> 32
-                self.mem.write(addr,value=int(dec_low))
+                self.mem.write(addr, value=int(dec_low))
                 addr = addr + 4
-                self.mem.write(addr,value=int(dec_high))
-                addr = addr + 4   
-                
+                self.mem.write(addr, value=int(dec_high))
+                addr = addr + 4
+
     def single_read(self, addr):
         """
         Reads one sample of tProc data memory using AXI access
@@ -1103,12 +1126,12 @@ class AxisTProc64x32_x8(SocIp):
         """
         # Address should be translated to upper map.
         addr_temp = 4*addr + self.DMEM_OFFSET
-            
+
         # Read data.
         data = self.read(addr_temp)
-            
+
         return data
-    
+
     def single_write(self, addr=0, data=0):
         """
         Writes one sample of tProc data memory using AXI access
@@ -1120,10 +1143,10 @@ class AxisTProc64x32_x8(SocIp):
         """
         # Address should be translated to upper map.
         addr_temp = 4*addr + self.DMEM_OFFSET
-            
+
         # Write data.
-        self.write(addr_temp,value=int(data))
-        
+        self.write(addr_temp, value=int(data))
+
     def load_dmem(self, buff_in, addr=0):
         """
         Writes tProc data memory using DMA
@@ -1135,17 +1158,17 @@ class AxisTProc64x32_x8(SocIp):
         """
         # Length.
         length = len(buff_in)
-        
+
         # Configure dmem arbiter.
         self.mem_mode_reg = 1
         self.mem_addr_reg = addr
         self.mem_len_reg = length
-        
+
         # Define buffer.
         self.buff = allocate(shape=length, dtype=np.int32)
-        
+
         # Copy buffer.
-        np.copyto(self.buff,buff_in)
+        np.copyto(self.buff, buff_in)
 
         # Start operation on block.
         self.mem_start_reg = 1
@@ -1156,7 +1179,7 @@ class AxisTProc64x32_x8(SocIp):
 
         # Set block back to single mode.
         self.mem_start_reg = 0
-        
+
     def read_dmem(self, addr=0, length=100):
         """
         Reads tProc data memory using DMA
@@ -1172,10 +1195,10 @@ class AxisTProc64x32_x8(SocIp):
         self.mem_mode_reg = 0
         self.mem_addr_reg = addr
         self.mem_len_reg = length
-        
+
         # Define buffer.
         buff = allocate(shape=length, dtype=np.int32)
-        
+
         # Start operation on block.
         self.mem_start_reg = 1
 
@@ -1185,9 +1208,10 @@ class AxisTProc64x32_x8(SocIp):
 
         # Set block back to single mode.
         self.mem_start_reg = 0
-        
+
         return buff
-    
+
+
 class AxisSwitch(SocIp):
     """
     AxisSwitch class to control Xilinx AXI-Stream switch IP
@@ -1201,30 +1225,30 @@ class AxisSwitch(SocIp):
     """
     bindto = ['xilinx.com:ip:axis_switch:1.1']
     REGISTERS = {'ctrl': 0x0, 'mix_mux': 0x040}
-    
+
     def __init__(self, description, **kwargs):
         """
         Constructor method
         """
         super().__init__(description)
-        
+
         # Number of slave interfaces.
         self.NSL = int(description['parameters']['NUM_SI'])
         # Number of master interfaces.
         self.NMI = int(description['parameters']['NUM_MI'])
-        
+
         # Init axis_switch.
         self.ctrl = 0
         self.disable_ports()
-            
+
     def disable_ports(self):
         """
         Disables ports
         """
         for ii in range(self.NMI):
             offset = self.REGISTERS['mix_mux'] + 4*ii
-            self.write(offset,0x80000000)
-        
+            self.write(offset, 0x80000000)
+
     def sel(self, mst=0, slv=0):
         """
         Digitally connects a master interface with a slave interface
@@ -1235,25 +1259,28 @@ class AxisSwitch(SocIp):
         :type slv: int
         """
         # Sanity check.
-        if slv>self.NSL-1:
-            print("%s: Slave number %d does not exist in block." % __class__.__name__)
+        if slv > self.NSL-1:
+            print("%s: Slave number %d does not exist in block." %
+                  __class__.__name__)
             return
-        if mst>self.NMI-1:
-            print("%s: Master number %d does not exist in block." % __class__.__name__)
+        if mst > self.NMI-1:
+            print("%s: Master number %d does not exist in block." %
+                  __class__.__name__)
             return
-        
+
         # Disable register update.
         self.ctrl = 0
 
         # Disable all MI ports.
         self.disable_ports()
-        
+
         # MI[mst] -> SI[slv]
         offset = self.REGISTERS['mix_mux'] + 4*mst
-        self.write(offset,slv)
+        self.write(offset, slv)
 
         # Enable register update.
-        self.ctrl = 2     
+        self.ctrl = 2
+
 
 class RFDC(xrfdc.RFdc):
     """
@@ -1264,28 +1291,29 @@ class RFDC(xrfdc.RFdc):
 
     def __init__(self, description):
         super().__init__(description)
-    
-    def set_freq(self,f,tile,dac):
+
+    def set_freq(self, f, tile, dac):
         # Make a copy of mixer settings.
-        dac_mixer = self.dac_tiles[tile].blocks[dac].MixerSettings        
+        dac_mixer = self.dac_tiles[tile].blocks[dac].MixerSettings
         new_mixcfg = dac_mixer.copy()
 
         # Update the copy
         new_mixcfg.update({
             'EventSource': xrfdc.EVNT_SRC_IMMEDIATE,
-            'Freq' : f,
+            'Freq': f,
             'MixerType': xrfdc.MIXER_TYPE_FINE,
-            'PhaseOffset' : 0})
+            'PhaseOffset': 0})
 
-        # Update settings.                
+        # Update settings.
         self.dac_tiles[tile].blocks[dac].MixerSettings = new_mixcfg
         self.dac_tiles[tile].blocks[dac].UpdateEvent(xrfdc.EVENT_MIXER)
-       
-    def set_nyquist(self,nz,tile,dac):
+
+    def set_nyquist(self, nz, tile, dac):
         dac_tile = self.dac_tiles[tile]
         dac_block = dac_tile.blocks[dac]
-        dac_block.NyquistZone = nz  
-        
+        dac_block.NyquistZone = nz
+
+
 class QickSoc(Overlay, QickConfig):
     """
     QickSoc class. This class will create all object to access system blocks
@@ -1299,15 +1327,15 @@ class QickSoc(Overlay, QickConfig):
     """
 
     # The following constants are no longer used. Some of the values may not match the bitfile.
-    #fs_adc = 384*8 # MHz
-    #fs_dac = 384*16 # MHz
-    #pulse_mem_len_IQ = 65536 # samples for I, Q
-    #ADC_decim_buf_len_IQ = 1024 # samples for I, Q
-    #ADC_accum_buf_len_IQ = 16384 # samples for I, Q
-    #tProc_instruction_len_bytes = 8 
+    # fs_adc = 384*8 # MHz
+    # fs_dac = 384*16 # MHz
+    # pulse_mem_len_IQ = 65536 # samples for I, Q
+    # ADC_decim_buf_len_IQ = 1024 # samples for I, Q
+    # ADC_accum_buf_len_IQ = 16384 # samples for I, Q
+    #tProc_instruction_len_bytes = 8
     #tProc_prog_mem_samples = 8000
     #tProc_prog_mem_size_bytes_tot = tProc_instruction_len_bytes*tProc_prog_mem_samples
-    #tProc_data_len_bytes = 4 
+    #tProc_data_len_bytes = 4
     #tProc_data_mem_samples = 4096
     #tProc_data_mem_size_bytes_tot = tProc_data_len_bytes*tProc_data_mem_samples
     #tProc_stack_len_bytes = 4
@@ -1315,18 +1343,20 @@ class QickSoc(Overlay, QickConfig):
     #tProc_stack_size_bytes_tot = tProc_stack_len_bytes*tProc_stack_samples
     #phase_resolution_bits = 32
     #gain_resolution_signed_bits = 16
-    
+
     # Constructor.
-    def __init__(self, bitfile=None, force_init_clks=False,ignore_version=True, **kwargs):
+    def __init__(self, bitfile=None, force_init_clks=False, ignore_version=True, **kwargs):
         """
         Constructor method
         """
         # Load bitstream. We read the bitstream configuration from the HWH file, but we don't program the FPGA yet.
         # We need to program the clocks first.
-        if bitfile==None:
-            Overlay.__init__(self, bitfile_path(), ignore_version=ignore_version, download=False, **kwargs)
+        if bitfile == None:
+            Overlay.__init__(self, bitfile_path(
+            ), ignore_version=ignore_version, download=False, **kwargs)
         else:
-            Overlay.__init__(self, bitfile, ignore_version=ignore_version, download=False, **kwargs)
+            Overlay.__init__(
+                self, bitfile, ignore_version=ignore_version, download=False, **kwargs)
 
         # Initialize the configuration
         self._cfg = {}
@@ -1335,7 +1365,8 @@ class QickSoc(Overlay, QickConfig):
         self['board'] = os.environ["BOARD"]
 
         # Read the config to get a list of enabled ADCs and DACs, and the sampling frequencies.
-        self.list_rf_blocks(self.ip_dict['usp_rf_data_converter_0']['parameters'])
+        self.list_rf_blocks(
+            self.ip_dict['usp_rf_data_converter_0']['parameters'])
 
         self.config_clocks(force_init_clks)
 
@@ -1374,19 +1405,20 @@ class QickSoc(Overlay, QickConfig):
         # Use the HWH parser to trace connectivity and deduce the channel numbering.
         # Since the HWH parser doesn't parse buses, we also make our own BusParser.
         busparser = BusParser(self.parser)
-        for key,val in self.ip_dict.items():
-            if hasattr(val['driver'],'configure_connections'):
-                getattr(self,key).configure_connections(self, self.parser, busparser)
+        for key, val in self.ip_dict.items():
+            if hasattr(val['driver'], 'configure_connections'):
+                getattr(self, key).configure_connections(
+                    self, self.parser, busparser)
 
         # AXIS Switch to upload samples into Signal Generators.
         self.switch_gen = self.axis_switch_gen
 
         # AXIS Switch to read samples from averager.
         self.switch_avg = self.axis_switch_avg
-        
+
         # AXIS Switch to read samples from buffer.
         self.switch_buf = self.axis_switch_buf
-        
+
         # Signal generators (anything driven by the tProc)
         self.gens = []
         gen_drivers = set([AxisSignalGen, AxisSgInt4V1, AxisSgMux4V1])
@@ -1401,30 +1433,33 @@ class QickSoc(Overlay, QickConfig):
         self.readouts = []
 
         # Populate the lists with the registered IP blocks.
-        for key,val in self.ip_dict.items():
+        for key, val in self.ip_dict.items():
             if (val['driver'] in gen_drivers):
-                self.gens.append(getattr(self,key))
+                self.gens.append(getattr(self, key))
             elif (val['driver'] == AxisConstantIQ):
-                self.iqs.append(getattr(self,key))
+                self.iqs.append(getattr(self, key))
             elif (val['driver'] == AxisReadoutV2):
-                self.readouts.append(getattr(self,key))
+                self.readouts.append(getattr(self, key))
             elif (val['driver'] == AxisAvgBuffer):
-                self.avg_bufs.append(getattr(self,key))
+                self.avg_bufs.append(getattr(self, key))
 
         # Sanity check: we should have the same number of signal generators as switch ports.
-        #TODO: update?
-        #if self.switch_gen.NMI != len(self.gens):
+        # TODO: update?
+        # if self.switch_gen.NMI != len(self.gens):
         #    raise RuntimeError("We have %d switch_gen outputs but %d signal generators."%(len(self.switch_gen.NMI),len(self.gens)))
 
         # Sanity check: we should have the same number of readouts and buffer blocks as switch ports.
         if len(self.readouts) != len(self.avg_bufs):
-            raise RuntimeError("We have %d readouts but %d avg/buffer blocks."%(len(self.readouts),len(self.avg_bufs)))
+            raise RuntimeError("We have %d readouts but %d avg/buffer blocks." %
+                               (len(self.readouts), len(self.avg_bufs)))
         if self.switch_avg.NSL != len(self.avg_bufs):
-            raise RuntimeError("We have %d switch_avg inputs but %d avg/buffer blocks."%(self.switch_avg.NSL,len(self.avg_bufs)))
+            raise RuntimeError("We have %d switch_avg inputs but %d avg/buffer blocks." %
+                               (self.switch_avg.NSL, len(self.avg_bufs)))
         if self.switch_buf.NSL != len(self.avg_bufs):
-            raise RuntimeError("We have %d switch_buf inputs but %d avg/buffer blocks."%(self.switch_buf.NSL,len(self.avg_bufs)))
+            raise RuntimeError("We have %d switch_buf inputs but %d avg/buffer blocks." %
+                               (self.switch_buf.NSL, len(self.avg_bufs)))
 
-        #TODO: get the trigger port
+        # TODO: get the trigger port
 
         # Sort the lists by channel number.
         # Typically they are already in order, but good to make sure?
@@ -1434,12 +1469,12 @@ class QickSoc(Overlay, QickConfig):
         self.readouts.sort(key=lambda x: x.buffer.switch_ch)
 
         # Fill the config dictionary with driver parameters.
-        self['b_dac'] = self.gens[0].B_DDS #typically 32
-        self['b_adc'] = self.readouts[0].B_DDS #typically 32
+        self['b_dac'] = self.gens[0].B_DDS  # typically 32
+        self['b_adc'] = self.readouts[0].B_DDS  # typically 32
 
         self['gens'] = []
         self['readouts'] = []
-        for iGen,gen in enumerate(self.gens):
+        for iGen, gen in enumerate(self.gens):
             thiscfg = {}
             thiscfg['type'] = gen.type
             thiscfg['maxlen'] = gen.MAX_LENGTH
@@ -1451,7 +1486,7 @@ class QickSoc(Overlay, QickConfig):
             thiscfg['f_fabric'] = self.dacs[gen.dac]['f_fabric']
             self['gens'].append(thiscfg)
 
-        for iBuf,buf in enumerate(self.avg_bufs):
+        for iBuf, buf in enumerate(self.avg_bufs):
             thiscfg = {}
             thiscfg['avg_maxlen'] = buf.AVG_MAX_LENGTH
             thiscfg['buf_maxlen'] = buf.BUF_MAX_LENGTH
@@ -1464,13 +1499,14 @@ class QickSoc(Overlay, QickConfig):
             self['readouts'].append(thiscfg)
 
         # Configure the drivers.
-        for i,gen in enumerate(self.gens):
-            gen.configure(i, self.axi_dma_gen, self.switch_gen, self.dacs[gen.dac]['fs'])
-        
-        for i,iq in enumerate(self.iqs):
+        for i, gen in enumerate(self.gens):
+            gen.configure(i, self.axi_dma_gen, self.switch_gen,
+                          self.dacs[gen.dac]['fs'])
+
+        for i, iq in enumerate(self.iqs):
             iq.configure(self.rf, self.dacs[gen.dac]['fs'])
 
-        for i,buf in enumerate(self.avg_bufs):
+        for i, buf in enumerate(self.avg_bufs):
             buf.configure(self.axi_dma_avg, self.switch_avg,
                           self.axi_dma_buf, self.switch_buf)
             buf.readout.configure(i, self.adcs[buf.readout.adc]['fs'])
@@ -1488,7 +1524,8 @@ class QickSoc(Overlay, QickConfig):
                 self.set_all_clks()
                 self.download()
         if not self.clocks_locked():
-            print("Not all DAC and ADC PLLs are locked. You may want to repeat the initialization of the QickSoc.")
+            print(
+                "Not all DAC and ADC PLLs are locked. You may want to repeat the initialization of the QickSoc.")
 
     def clocks_locked(self):
         """
@@ -1499,8 +1536,10 @@ class QickSoc(Overlay, QickConfig):
         :rtype: bool
         """
 
-        dac_locked = [self.usp_rf_data_converter_0.dac_tiles[iTile].PLLLockStatus==2 for iTile in self.dac_tiles]
-        adc_locked = [self.usp_rf_data_converter_0.adc_tiles[iTile].PLLLockStatus==2 for iTile in self.adc_tiles]
+        dac_locked = [self.usp_rf_data_converter_0.dac_tiles[iTile]
+                      .PLLLockStatus == 2 for iTile in self.dac_tiles]
+        adc_locked = [self.usp_rf_data_converter_0.adc_tiles[iTile]
+                      .PLLLockStatus == 2 for iTile in self.adc_tiles]
         return (all(dac_locked) and all(adc_locked))
 
     def list_rf_blocks(self, rf_config):
@@ -1510,7 +1549,7 @@ class QickSoc(Overlay, QickConfig):
         This re-implements that functionality.
         """
 
-        self.hs_adc = rf_config['C_High_Speed_ADC']=='1'
+        self.hs_adc = rf_config['C_High_Speed_ADC'] == '1'
 
         self.dac_tiles = []
         self.adc_tiles = []
@@ -1521,47 +1560,47 @@ class QickSoc(Overlay, QickConfig):
         self.adcs = {}
 
         for iTile in range(4):
-            if rf_config['C_DAC%d_Enable'%(iTile)]!='1':
+            if rf_config['C_DAC%d_Enable' % (iTile)] != '1':
                 continue
             self.dac_tiles.append(iTile)
-            f_fabric = float(rf_config['C_DAC%d_Fabric_Freq'%(iTile)])
-            f_refclk = float(rf_config['C_DAC%d_Refclk_Freq'%(iTile)])
+            f_fabric = float(rf_config['C_DAC%d_Fabric_Freq' % (iTile)])
+            f_refclk = float(rf_config['C_DAC%d_Refclk_Freq' % (iTile)])
             dac_fabric_freqs.append(f_fabric)
             refclk_freqs.append(f_refclk)
-            fs = float(rf_config['C_DAC%d_Sampling_Rate'%(iTile)])*1000
+            fs = float(rf_config['C_DAC%d_Sampling_Rate' % (iTile)])*1000
             for iBlock in range(4):
-                if rf_config['C_DAC_Slice%d%d_Enable'%(iTile,iBlock)]!='true':
+                if rf_config['C_DAC_Slice%d%d_Enable' % (iTile, iBlock)] != 'true':
                     continue
-                self.dacs["%d%d"%(iTile,iBlock)] = {'fs':fs,
-                                                    'f_fabric':f_fabric}
+                self.dacs["%d%d" % (iTile, iBlock)] = {'fs': fs,
+                                                       'f_fabric': f_fabric}
 
         for iTile in range(4):
-            if rf_config['C_ADC%d_Enable'%(iTile)]!='1':
+            if rf_config['C_ADC%d_Enable' % (iTile)] != '1':
                 continue
             self.adc_tiles.append(iTile)
-            f_fabric = float(rf_config['C_ADC%d_Fabric_Freq'%(iTile)])
-            f_refclk = float(rf_config['C_ADC%d_Refclk_Freq'%(iTile)])
+            f_fabric = float(rf_config['C_ADC%d_Fabric_Freq' % (iTile)])
+            f_refclk = float(rf_config['C_ADC%d_Refclk_Freq' % (iTile)])
             adc_fabric_freqs.append(f_fabric)
             refclk_freqs.append(f_refclk)
-            fs = float(rf_config['C_ADC%d_Sampling_Rate'%(iTile)])*1000
+            fs = float(rf_config['C_ADC%d_Sampling_Rate' % (iTile)])*1000
             for iBlock in range(4):
                 if self.hs_adc:
-                    if iBlock>=2 or rf_config['C_ADC_Slice%d%d_Enable'%(iTile,2*iBlock)]!='true':
+                    if iBlock >= 2 or rf_config['C_ADC_Slice%d%d_Enable' % (iTile, 2*iBlock)] != 'true':
                         continue
                 else:
-                    if rf_config['C_ADC_Slice%d%d_Enable'%(iTile,iBlock)]!='true':
+                    if rf_config['C_ADC_Slice%d%d_Enable' % (iTile, iBlock)] != 'true':
                         continue
-                self.adcs["%d%d"%(iTile,iBlock)] = {'fs':fs,
-                                                    'f_fabric':f_fabric}
+                self.adcs["%d%d" % (iTile, iBlock)] = {'fs': fs,
+                                                       'f_fabric': f_fabric}
 
         def get_common_freq(freqs):
             """
             Check that all elements of the list are equal, and return the common value.
             """
-            if not freqs: # input is empty list
+            if not freqs:  # input is empty list
                 return None
-            if len(set(freqs))!=1:
-                raise RuntimeError("Unexpected frequencies:",freqs)
+            if len(set(freqs)) != 1:
+                raise RuntimeError("Unexpected frequencies:", freqs)
             return freqs[0]
 
         self['refclk_freq'] = get_common_freq(refclk_freqs)
@@ -1570,15 +1609,15 @@ class QickSoc(Overlay, QickConfig):
         """
         Resets all the board clocks
         """
-        if self['board']=='ZCU111':
-            print("resetting clocks:",self['refclk_freq'])
+        if self['board'] == 'ZCU111':
+            print("resetting clocks:", self['refclk_freq'])
             xrfclk.set_all_ref_clks(self['refclk_freq'])
-        elif self['board']=='ZCU216':
+        elif self['board'] == 'ZCU216':
             lmk_freq = self['refclk_freq']
             lmx_freq = self['refclk_freq']*2
-            print("resetting clocks:",lmk_freq, lmx_freq)
+            print("resetting clocks:", lmk_freq, lmx_freq)
             xrfclk.set_ref_clks(lmk_freq=lmk_freq, lmx_freq=lmx_freq)
-    
+
     def get_decimated(self, ch, address=0, length=None):
         """
         Acquires data from the readout decimated buffer
@@ -1598,14 +1637,15 @@ class QickSoc(Overlay, QickConfig):
             length = self.avg_bufs[ch].BUF_MAX_LENGTH
 
         # we must transfer an even number of samples, so we pad the transfer size
-        transfer_len = length + length%2
+        transfer_len = length + length % 2
 
         # there is a bug which causes the first sample of a transfer to always be the sample at address 0
         # we work around this by requesting an extra 2 samples at the beginning
-        data = self.avg_bufs[ch].transfer_buf((address-2)%self.avg_bufs[ch].BUF_MAX_LENGTH,transfer_len+2)
+        data = self.avg_bufs[ch].transfer_buf(
+            (address-2) % self.avg_bufs[ch].BUF_MAX_LENGTH, transfer_len+2)
 
         # we remove the padding here
-        return data[:,2:length+2].astype(float)
+        return data[:, 2:length+2].astype(float)
 
     def get_accumulated(self, ch, address=0, length=None):
         """
@@ -1627,15 +1667,16 @@ class QickSoc(Overlay, QickConfig):
             length = self.avg_bufs[ch].AVG_MAX_LENGTH
 
         # we must transfer an even number of samples, so we pad the transfer size
-        transfer_len = length + length%2
+        transfer_len = length + length % 2
 
         # there is a bug which causes the first sample of a transfer to always be the sample at address 0
         # we work around this by requesting an extra 2 samples at the beginning
-        data = self.avg_bufs[ch].transfer_avg((address-2)%self.avg_bufs[ch].AVG_MAX_LENGTH,transfer_len+2)
+        data = self.avg_bufs[ch].transfer_avg(
+            (address-2) % self.avg_bufs[ch].AVG_MAX_LENGTH, transfer_len+2)
 
         # we remove the padding here
-        return data[:,2:length+2]
-    
+        return data[:, 2:length+2]
+
     def configure_readout(self, ch, output, frequency):
         """Configure readout channel output style and frequency
         :param ch: Channel to configure
@@ -1660,10 +1701,10 @@ class QickSoc(Overlay, QickConfig):
         self.avg_bufs[ch].config_avg(address, length)
         if enable:
             self.enable_avg(ch)
-        
+
     def enable_avg(self, ch):
         self.avg_bufs[ch].enable_avg()
-    
+
     def config_buf(self, ch, address=0, length=1, enable=True):
         """Configure and optionally enable decimation buffer
         :param ch: Channel to configure
@@ -1681,7 +1722,7 @@ class QickSoc(Overlay, QickConfig):
 
     def enable_buf(self, ch):
         self.avg_bufs[ch].enable_buf()
-        
+
     def get_avg_max_length(self, ch=0):
         """Get accumulation buffer length for channel
         :param ch: Channel
@@ -1702,7 +1743,7 @@ class QickSoc(Overlay, QickConfig):
         :param addr: address to start data at
         :type addr: int
         """
-        return self.gens[ch-1].load(xin_i=idata, xin_q=qdata, addr=addr)                 
+        return self.gens[ch-1].load(xin_i=idata, xin_q=qdata, addr=addr)
 
     def set_nyquist(self, ch, nqz):
         """
@@ -1716,6 +1757,6 @@ class QickSoc(Overlay, QickConfig):
         :type nqz: int
         """
         #ch_info={1: (0,0), 2: (0,1), 3: (0,2), 4: (1,0), 5: (1,1), 6: (1, 2), 7: (1,3)}
-    
+
         tile, channel = [int(a) for a in self['gens'][ch-1]['dac']]
         self.rf.set_nyquist(nqz, tile, channel)

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -249,7 +249,7 @@ class AxisSignalGen(AbsSignalGen):
         """
         self.rndq_reg = sel_
                 
-class AxisSgInt4V1(SocIp):
+class AxisSgInt4V1(AbsSignalGen):
     """
     AxisSgInt4V1
 
@@ -412,7 +412,7 @@ class AxisConstantIQ(SocIp):
         # port names are of the form 's00_axis'
         self.dac = port[1:3]        
 
-    def config(self, rf, fs):
+    def configure(self, rf, fs):
         # RFDC
         self.rf = rf
         # sampling frequency
@@ -1259,7 +1259,8 @@ class RFDC(xrfdc.RFdc):
     """
     Extends the xrfdc driver.
     """
-    bindto = ["xilinx.com:ip:usp_rf_data_converter:2.3"]
+    bindto = ["xilinx.com:ip:usp_rf_data_converter:2.3",
+              "xilinx.com:ip:usp_rf_data_converter:2.4"]
 
     def __init__(self, description):
         super().__init__(description)
@@ -1404,7 +1405,7 @@ class QickSoc(Overlay, QickConfig):
             if (val['driver'] in gen_drivers):
                 self.gens.append(getattr(self,key))
             elif (val['driver'] == AxisConstantIQ):
-                self.avg_bufs.append(getattr(self,key))
+                self.iqs.append(getattr(self,key))
             elif (val['driver'] == AxisReadoutV2):
                 self.readouts.append(getattr(self,key))
             elif (val['driver'] == AxisAvgBuffer):

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -75,6 +75,12 @@ class QickConfig():
             lines.append("\t\tDAC tile %s, ch %s, %d-bit DDS, fabric=%.3f MHz, fs=%.3f MHz" %
                          (*gen['dac'], gen['b_dds'], gen['f_fabric'], gen['fs']))
 
+        if self['iqs']:
+            lines.append("\n\t%d constant-IQ outputs:" % (len(self['iqs'])))
+            for iIQ, iq in enumerate(self['iqs']):
+                lines.append("\t%d:\tDAC tile %s, ch %s, fs=%.3f MHz" %
+                             (iIQ, *iq['dac'], iq['fs']))
+
         lines.append("\n\t%d readout channels:" % (len(self['readouts'])))
         for iReadout, readout in enumerate(self['readouts']):
             lines.append("\t%d:\tADC tile %s, ch %s, %d-bit DDS, fabric=%.3f MHz, fs=%.3f MHz" %

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -374,6 +374,7 @@ class QickProgram:
         self.ro_chs[ch] = ReadoutConfig(freq, length, sel, gen_ch)
 
     def config_readouts(self, soc):
+        soc.init_readouts()
         for ch, cfg in self.ro_chs.items():
             if cfg.gen_ch is not None:
                 gen_cfg = self.gen_chs[cfg.gen_ch]

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -1000,6 +1000,15 @@ class QickProgram:
         """
         return [self.compile_instruction(inst, debug=debug) for inst in self.prog_list]
 
+    def load_program(self, soc, debug=False):
+        """
+        Load the compiled program into the tProcessor.
+
+        :param debug: If True, debug mode is on
+        :type debug: bool
+        """
+        soc.tproc.load_bin_program(self.compile(debug=debug))
+
     def get_mode_code(self, length, mode=None, outsel=None, stdysel=None, phrst=None):
         """
         Creates mode code for the mode register in the set command, by setting flags and adding the pulse length.

--- a/qick_lib/qick/rfboard.py
+++ b/qick_lib/qick/rfboard.py
@@ -9,6 +9,7 @@ from pynq import allocate
 from pynq.lib import AxiGPIO
 import time
 
+
 class AxisSignalGenV3(SocIp):
     # AXIS Table Registers.
     # START_ADDR_REG
@@ -18,52 +19,52 @@ class AxisSignalGenV3(SocIp):
     # * 1 : enable writes.
     #
     bindto = ['user.org:user:axis_signal_gen_v3:1.0']
-    REGISTERS = {'start_addr_reg':0, 'we_reg':1}
-    
+    REGISTERS = {'start_addr_reg': 0, 'we_reg': 1}
+
     # Generics
     N = 12
     NDDS = 16
-    
+
     # Maximum number of samples
     MAX_LENGTH = 2**N*NDDS
-    
+
     def __init__(self, description, **kwargs):
         super().__init__(description)
 
     def config(self, axi_dma, dds_mr_switch, axis_switch, channel, name, **kwargs):
         # Default registers.
-        self.start_addr_reg=0
-        self.we_reg=0
-        
+        self.start_addr_reg = 0
+        self.we_reg = 0
+
         # dma
         self.dma = axi_dma
-        
+
         # Real/imaginary selection switch.
         self.iq_switch = AxisDdsMrSwitch(dds_mr_switch)
-        
+
         # switch
         self.switch = axis_switch
-        
+
         # Channel.
         self.ch = channel
-        
+
         # Name.
         self.name = name
-        
+
     # Load waveforms.
-    def load(self, buff_in,addr=0):
+    def load(self, buff_in, addr=0):
         # Route switch to channel.
         self.switch.sel(slv=self.ch)
-        
+
         time.sleep(0.1)
-        
+
         # Define buffer.
         self.buff = allocate(shape=(len(buff_in)), dtype=np.int16)
-        
+
         ###################
         ### Load I data ###
         ###################
-        np.copyto(self.buff,buff_in)
+        np.copyto(self.buff, buff_in)
 
         # Enable writes.
         self.wr_enable(addr)
@@ -73,73 +74,74 @@ class AxisSignalGenV3(SocIp):
         self.dma.sendchannel.wait()
 
         # Disable writes.
-        self.wr_disable()        
-        
-    def wr_enable(self,addr=0):
+        self.wr_disable()
+
+    def wr_enable(self, addr=0):
         self.start_addr_reg = addr
         self.we_reg = 1
-        
+
     def wr_disable(self):
         self.we_reg = 0
-        
+
+
 class AxisSignalGenV3Ctrl(SocIp):
     # Signal Generator V3 Control registers.
     # ADDR_REG
     bindto = ['user.org:user:axis_signal_gen_v3_ctrl:1.0']
     REGISTERS = {
-        'freq'    : 0,
-        'phase'   : 1,
-        'addr'    : 2,
-        'gain'    : 3,
-        'nsamp'   : 4,
-        'outsel'  : 5,
-        'mode'    : 6,
-        'stdysel' : 7,
-        'we'      : 8}
-    
+        'freq': 0,
+        'phase': 1,
+        'addr': 2,
+        'gain': 3,
+        'nsamp': 4,
+        'outsel': 5,
+        'mode': 6,
+        'stdysel': 7,
+        'we': 8}
+
     # Generics of Signal Generator.
-    N     = 10
-    NDDS  = 16
-    B     = 16
-    MAX_v = np.power(2,B)-1
-    
+    N = 10
+    NDDS = 16
+    B = 16
+    MAX_v = np.power(2, B)-1
+
     # Sampling frequency.
-    fs    = 4096
-    
+    fs = 4096
+
     def __init__(self, description, **kwargs):
         super().__init__(description)
-        
+
         # Default registers.
-        self.freq    = 0
-        self.phase   = 0
-        self.addr    = 0
-        self.gain    = 30000
-        self.nsamp   = 16*100
-        self.outsel  = 1 # dds
-        self.mode    = 1 # periodic
-        self.stdysel = 1 # zero
-        self.we      = 0
-        
-    def add(self, 
-            freq = 0, 
-            phase = 0, 
-            addr = 0, 
-            gain = 30000, 
-            nsamp = 16*100, 
-            outsel = "dds", 
-            mode = "periodic", 
-            stdysel = "zero"):
-        
+        self.freq = 0
+        self.phase = 0
+        self.addr = 0
+        self.gain = 30000
+        self.nsamp = 16*100
+        self.outsel = 1  # dds
+        self.mode = 1  # periodic
+        self.stdysel = 1  # zero
+        self.we = 0
+
+    def add(self,
+            freq=0,
+            phase=0,
+            addr=0,
+            gain=30000,
+            nsamp=16*100,
+            outsel="dds",
+            mode="periodic",
+            stdysel="zero"):
+
         # Input frequency is in MHz.
-        w0 = 2*np.pi*freq/self.fs  
+        w0 = 2*np.pi*freq/self.fs
         freq_tmp = w0/(2*np.pi)*self.MAX_v
-        
-        self.freq    = int(np.round(freq_tmp))
-        self.phase   = phase
-        self.addr    = addr
-        self.gain    = gain
-        self.nsamp   = int(np.round(nsamp/self.NDDS))
-        
+
+        self.freq = int(np.round(freq_tmp))
+        self.phase = phase
+        self.addr = addr
+        self.gain = gain
+        self.nsamp = int(np.round(nsamp/self.NDDS))
+
         if outsel == "product":
             self.outsel = 0
         elif outsel == "dds":
@@ -162,15 +164,16 @@ class AxisSignalGenV3Ctrl(SocIp):
             self.stdysel = 1
         else:
             print("AxisSignalGenV3Ctrl: %s stdysel unknown" % stdysel)
-        
+
         # Write fifo..
         self.we = 1
         time.sleep(0.1)
-        self.we = 0        
-        
-    def set_fs(self,fs):
+        self.we = 0
+
+    def set_fs(self, fs):
         self.fs = fs
-        
+
+
 class AxisDdsMrSwitch(SocIp):
     # AXIS DDS MR SWITCH registers.
     # DDS_REAL_IMAG_REG
@@ -178,26 +181,27 @@ class AxisDdsMrSwitch(SocIp):
     # * 1 : imaginary part.
     #
     bindto = ['user.org:user:axis_dds_mr_switch:1.0']
-    REGISTERS = {'dds_real_imag' : 0}
-    
+    REGISTERS = {'dds_real_imag': 0}
+
     def __init__(self, description, **kwargs):
         """
         Constructor method
         """
         super().__init__(description)
-        
+
         # Default registers.
         # dds_real_imag = 0  : take real part.
         self.dds_real_imag = 0
-        
+
     def config(self, reg_):
         self.dds_real_imag = reg_
-        
+
     def real(self):
         self.config(0)
-        
+
     def imag(self):
         self.config(1)
+
 
 class spi(SocIp):
 
@@ -217,23 +221,23 @@ class spi(SocIp):
     SSR = 0x70    # 0x70 - RW - SPI Slave Select Register
     TFOR = 0x74   # 0x74 - RW - SPI Transmit FIFO Occupancy Register
     RFOR = 0x78   # 0x78 - RO - SPI Receive FIFO Occupancy Register
-    
+
     def __init__(self, description, **kwargs):
         super().__init__(description)
-        
+
         # Soft reset SPI.
         self.rst()
-        
+
         # De-assert slave select
-        self.reg_wr("SSR",0)
-    
+        self.reg_wr("SSR", 0)
+
     # Number of channels (to control CS/LE).
     NCH = 1
-        
+
     # Register read.
-    def reg_rd(self,reg="CR"):
+    def reg_rd(self, reg="CR"):
         reg_val = -1
-        
+
         if reg == "CR":
             reg_val = self.read(self.CR)
         elif reg == "SR":
@@ -251,24 +255,26 @@ class spi(SocIp):
         elif reg == "RFOR":
             reg_val = self.read(self.RFOR)
         else:
-            print("%s: register %s not recognized." %(self.__class__.__name__,reg))            
-            
+            print("%s: register %s not recognized." %
+                  (self.__class__.__name__, reg))
+
         return reg_val
-    
+
     # Register write.
-    def reg_wr(self,reg="CR",reg_val=0):
+    def reg_wr(self, reg="CR", reg_val=0):
         if reg == "CR":
-            self.write(self.CR,reg_val)
+            self.write(self.CR, reg_val)
         elif reg == "SSR":
-            self.write(self.SSR,reg_val)
+            self.write(self.SSR, reg_val)
         elif reg == "DGIER":
-            self.write(self.DGIER,reg_val)
+            self.write(self.DGIER, reg_val)
         else:
-            print("%s: register %s not recognized." %(self.__class__.__name__,reg))
-    
+            print("%s: register %s not recognized." %
+                  (self.__class__.__name__, reg))
+
     def rst(self):
-        self.write(self.SRR,0xA)
-    
+        self.write(self.SRR, 0xA)
+
     # SPI Control Register:
     # Bit 9 : LSB/MSB selection.
     # -> 0 : MSB first
@@ -291,8 +297,8 @@ class spi(SocIp):
     # -> 1 : Reset RX FIFO.
     #
     # Bit 4 : Clock Phase.
-    # -> 0 : 
-    # -> 1 : 
+    # -> 0 :
+    # -> 1 :
     #
     # Bit 3 : Clock Polarity.
     # -> 0 : Active-High clock. SCK idles low.
@@ -310,65 +316,65 @@ class spi(SocIp):
     # -> 0 : Normal operation.
     # -> 1 : Loopback mode.
     def config(self,
-                lsb="lsb",
-                msttran="enable",
-                ssmode="ssr",
-                rxfifo="normal",
-                txfifo="normal",
-                cpha="",
-                cpol="high",
-                mst="master",
-                en="enable",
-                loopback="no"):
-        
+               lsb="lsb",
+               msttran="enable",
+               ssmode="ssr",
+               rxfifo="normal",
+               txfifo="normal",
+               cpha="",
+               cpol="high",
+               mst="master",
+               en="enable",
+               loopback="no"):
+
         # Config word.
         tmp = 0
-        
+
         # LSB/MSB.
         if lsb == "lsb":
             tmp |= (1 << 9)
-            
+
         # Master transaction inhibit.
         if msttran == "disable":
             tmp |= (1 << 8)
-            
+
         # Manual slave select.
         if ssmode == "ssr":
             tmp |= (1 << 7)
-            
+
         # RX FIFO.
         if rxfifo == "rst":
             tmp |= (1 << 6)
-            
+
         # TX FIFO.
         if txfifo == "rst":
             tmp |= (1 << 5)
-            
+
         # CPHA.
         if cpha == "invert":
             tmp |= (1 << 4)
-        
+
         # CPOL
         if cpol == "low":
             tmp |= (1 << 3)
-            
+
         # Master mode.
         if mst == "master":
             tmp |= (1 << 2)
-            
+
         # SPI enable.
         if en == "enable":
             tmp |= (1 << 1)
-            
+
         # Loopback
         if loopback == "yes":
             tmp |= (1 << 0)
-                       
+
         # Write register.
         self.reg_wr("CR", tmp)
-        
+
         return tmp
-    
+
     # Enable function.
     def en_level(self, nch=4, chlist=[0], en_l="high"):
         ch_en = 0
@@ -379,42 +385,42 @@ class spi(SocIp):
             ch_en = 2**nch - 1
             for i in range(len(chlist)):
                 ch_en &= ~(1 << chlist[i])
-                
+
         return ch_en
-    
+
     # Send function.
-    def send_m(self, data, n=1, nch=4, chlist=[0], en_l="high",cs_t="pulse"):
+    def send_m(self, data, n=1, nch=4, chlist=[0], en_l="high", cs_t="pulse"):
         # Manually assert channels.
         ch_en = self.en_level(nch, chlist, en_l)
         ch_en_temp = self.reg_rd("SSR")
-        
+
         # Standard CS at the beginning of transaction.
         if cs_t != "pulse":
             self.reg_wr("SSR", ch_en)
-        
+
         # Send data.
         for i in range(n):
             # Send data.
-            self.write(self.DTR,data[i])
-            
+            self.write(self.DTR, data[i])
+
             # LE pulse at the end.
             if cs_t == "pulse":
                 # Write SSR to enable channels.
-                self.reg_wr("SSR",ch_en)
-            
+                self.reg_wr("SSR", ch_en)
+
                 # Write SSR to previous value.
-                self.reg_wr("SSR",ch_en_temp)
-        
+                self.reg_wr("SSR", ch_en_temp)
+
         # Bring CS to default value.
         if cs_t != "pulse":
             self.reg_wr("SSR", ch_en_temp)
-            
+
     # Receive function.
     def receive(self):
         # Check if fifo is empty.
         status = self.reg_rd("SR")
-        status &= 0x1 # mask to get only rx empty bit.
-        
+        status &= 0x1  # mask to get only rx empty bit.
+
         # Fifo is empty
         if status:
             return []
@@ -425,254 +431,266 @@ class spi(SocIp):
             for i in range(nr):
                 data_r[i] = self.read(self.DRR)
             return data_r
-        
+
     # Send/Receive.
-    def send_receive_m(self,data,n=1,nch=4,chlist=[0],en_l="high",cs_t="pulse"):      
-        self.send_m(data,n,nch,chlist,en_l,cs_t)
+    def send_receive_m(self, data, n=1, nch=4, chlist=[0], en_l="high", cs_t="pulse"):
+        self.send_m(data, n, nch, chlist, en_l, cs_t)
         data_r = self.receive()
-    
+
         return data_r
-    
+
 # Step Attenuator PE43705.
 # Parts are used in serial mode.
 # See schematics for Address/LE correspondance.
+
+
 class PE43705:
     address = 0
     nSteps = 2**7
     dbStep = 0.25
     dbMinAtt = 0
     dbMaxAtt = (nSteps-1)*dbStep
-    
-    def __init__(self,address=0):
+
+    def __init__(self, address=0):
         self.address = address
-    
-    def db2step(self,db):
+
+    def db2step(self, db):
         ret = -1
-        
+
         # Sanity check.
         if db < self.dbMinAtt:
-            print("%s: attenuation value %f out of range" %(self.__class__.__name__,db))            
+            print("%s: attenuation value %f out of range" %
+                  (self.__class__.__name__, db))
         elif db > self.dbMaxAtt:
-            print("%s: attenuation value %f out of range" %(self.__class__.__name__,db))
+            print("%s: attenuation value %f out of range" %
+                  (self.__class__.__name__, db))
         else:
             ret = int(np.round(db/self.dbStep))
-    
+
         return ret
-    
-    def db2reg(self,db):
+
+    def db2reg(self, db):
         reg = 0
-        
+
         # Steps.
         reg |= self.db2step(db)
-        
+
         # Address.
         reg |= (self.address << 8)
-        
+
         return reg
-    
+
 # GPIO chip MCP23S08.
 # All are used with address 0.
+
+
 class MCP23S08:
     # Commands.
     cmd_wr = 0x40
     cmd_rd = 0x41
-    
+
     # Registers.
-    REGS = {'IODIR_REG'   : 0x00,
-            'IPOL_REG'    : 0x01,
-            'GPINTEN_REG' : 0x02,
-            'DEFVAL_REG'  : 0x03,
-            'INTCON_REG'  : 0x04,
-            'IOCON_REG'   : 0x05,
-            'GPPU_REG'    : 0x06,
-            'INTF_REG'    : 0x07,
-            'INTCAP_REG'  : 0x08,
-            'GPIO_REG'    : 0x09,
-            'OLAT_REG'    : 0x0A}
-    
+    REGS = {'IODIR_REG': 0x00,
+            'IPOL_REG': 0x01,
+            'GPINTEN_REG': 0x02,
+            'DEFVAL_REG': 0x03,
+            'INTCON_REG': 0x04,
+            'IOCON_REG': 0x05,
+            'GPPU_REG': 0x06,
+            'INTF_REG': 0x07,
+            'INTCAP_REG': 0x08,
+            'GPIO_REG': 0x09,
+            'OLAT_REG': 0x0A}
+
     # Register/address mapping.
-    def reg2addr(self,reg="GPIO_REG"):
+    def reg2addr(self, reg="GPIO_REG"):
         if reg in self.REGS:
             return self.REGS[reg]
         else:
-            print("%s: register %s not recognized." %(self.__class__.__name__,reg))
+            print("%s: register %s not recognized." %
+                  (self.__class__.__name__, reg))
             return -1
-    
+
     # Data array: 3 bytes.
     # byte[0] = opcode.
     # byte[1] = register address.
     # byte[2] = register value (dummy for read).
-    def reg_rd(self,reg="GPIO_REG"):
+    def reg_rd(self, reg="GPIO_REG"):
         byte = []
-        
+
         # Read command.
         byte.append(self.cmd_rd)
-        
+
         # Address.
         addr = self.reg2addr(reg)
         byte.append(addr)
-        
+
         # Dummy byte for clocking data out.
         byte.append(0)
-        
+
         return byte
-    
-    def reg_wr(self,reg="GPIO_REG",val=0):
+
+    def reg_wr(self, reg="GPIO_REG", val=0):
         byte = []
-        
+
         # Write command.
         byte.append(self.cmd_wr)
-        
+
         # Address.
         addr = self.reg2addr(reg)
         byte.append(addr)
-        
+
         # Dummy byte for clocking data out.
         byte.append(val)
-        
-        return byte    
-    
+
+        return byte
+
 # LO Chip ADF4372.
+
+
 class ADF4372:
     # Reference input.
     f_REF_in = 122.88
-    
+
     # Fixed 25-bit modulus.
     MOD1 = 2**25
-    
+
     # Commands.
     cmd_wr = 0x00
     cmd_rd = 0x80
-    
+
     # Registers.
-    REGS = {'CONFIG0_REG'       : 0x00,
-            'CONFIG1_REG'       : 0x01,
-            'CHIP_REG'          : 0x03,
-            'PROD_ID0_REG'      : 0x04,
-            'PROD_ID1_REG'      : 0x05,
-            'PROD_REV_REG'      : 0x06,
-            'INT_LOW_REG'       : 0x10,
-            'INT_HIGH_REG'      : 0x11,
-            'CAL_PRE_REG'       : 0x12,
-            'FRAC1_LOW_REG'     : 0x14,
-            'FRAC1_MID_REG'     : 0x15,
-            'FRAC1_HIGH_REG'    : 0x16,
-            'FRAC2_LOW_REG'     : 0x17, # NOTE: bit zero is the MSB of FRAC1.
-            'FRAC2_HIGH_REG'    : 0x18,
-            'MOD2_LOW_REG'      : 0x19,
-            'MOD2_HIGH_REG'     : 0x1A, # NOTE: bi 6 is PHASE_ADJ.
-            'PHASE_LOW_REG'     : 0x1B,
-            'PHASE_MID_REG'     : 0x1C,
-            'PHASE_HIGH_REG'    : 0x1D,
-            'CONFIG2_REG'       : 0x1E,
-            'RCNT_REG'          : 0x1F,
-            'MUXOUT_REG'        : 0x20,
-            'REF_REG'           : 0x22,
-            'CONFIG3_REG'       : 0x23,
-            'RFDIV_REG'         : 0x24,
-            'RFOUT_REG'         : 0x25,
-            'BLEED0_REG'        : 0x26,
-            'BLEED1_REG'        : 0x27,
-            'LOCK_REG'          : 0x28,
-            'CONFIG4_REG'       : 0x2A,
-            'SD_REG'            : 0x2B,
-            'VCO_BIAS0_REG'     : 0x2C,
-            'VCO_BIAS1_REG'     : 0x2D,
-            'VCO_BIAS2_REG'     : 0x2E,
-            'VCO_BIAS3_REG'     : 0x2F,
-            'VCO_BAND_REG'      : 0x30,
-            'TIMEOUT_REG'       : 0x31,
-            'ADC_REG'           : 0x32,
-            'SYNTH_TIMEOUT_REG' : 0x33,
-            'VCO_TIMEOUT_REG'   : 0x34,
-            'ADC_CLK_REG'       : 0x35,
-            'ICP_OFFSET_REG'    : 0x36,
-            'SI_BAND_REG'       : 0x37,
-            'SI_VCO_REG'        : 0x38,
-            'SI_VTUNE_REG'      : 0x39,
-            'ADC_OFFSET_REG'    : 0x3A,
-            'SD_RESET_REG'      : 0x3D,
-            'CP_TMODE_REG'      : 0x3E,
-            'CLK1_DIV_LOW_REG'  : 0x3F,
-            'CLK1_DIV_HIGH_REG' : 0x40,
-            'CLK2_DIV_REG'      : 0x41,
-            'TRM_RESD0_REG'     : 0x47,
-            'TRM_RESD1_REG'     : 0x52,
-            'VCO_DATA_LOW_REG'  : 0x6E,
-            'VCO_DATA_HIGH_REG' : 0x6F,
-            'BIAS_SEL_X2_REG'   : 0x70,
-            'BIAS_SEL_X4_REG'   : 0x71,
-            'AUXOUT_REG'        : 0x72,
-            'LD_PD_ADC_REG'     : 0x73,
-            'LOCK_DETECT_REG'   : 0x7C}
-    
-    def reg2addr(self,reg="CONFIG0_REG"):
+    REGS = {'CONFIG0_REG': 0x00,
+            'CONFIG1_REG': 0x01,
+            'CHIP_REG': 0x03,
+            'PROD_ID0_REG': 0x04,
+            'PROD_ID1_REG': 0x05,
+            'PROD_REV_REG': 0x06,
+            'INT_LOW_REG': 0x10,
+            'INT_HIGH_REG': 0x11,
+            'CAL_PRE_REG': 0x12,
+            'FRAC1_LOW_REG': 0x14,
+            'FRAC1_MID_REG': 0x15,
+            'FRAC1_HIGH_REG': 0x16,
+            'FRAC2_LOW_REG': 0x17,  # NOTE: bit zero is the MSB of FRAC1.
+            'FRAC2_HIGH_REG': 0x18,
+            'MOD2_LOW_REG': 0x19,
+            'MOD2_HIGH_REG': 0x1A,  # NOTE: bi 6 is PHASE_ADJ.
+            'PHASE_LOW_REG': 0x1B,
+            'PHASE_MID_REG': 0x1C,
+            'PHASE_HIGH_REG': 0x1D,
+            'CONFIG2_REG': 0x1E,
+            'RCNT_REG': 0x1F,
+            'MUXOUT_REG': 0x20,
+            'REF_REG': 0x22,
+            'CONFIG3_REG': 0x23,
+            'RFDIV_REG': 0x24,
+            'RFOUT_REG': 0x25,
+            'BLEED0_REG': 0x26,
+            'BLEED1_REG': 0x27,
+            'LOCK_REG': 0x28,
+            'CONFIG4_REG': 0x2A,
+            'SD_REG': 0x2B,
+            'VCO_BIAS0_REG': 0x2C,
+            'VCO_BIAS1_REG': 0x2D,
+            'VCO_BIAS2_REG': 0x2E,
+            'VCO_BIAS3_REG': 0x2F,
+            'VCO_BAND_REG': 0x30,
+            'TIMEOUT_REG': 0x31,
+            'ADC_REG': 0x32,
+            'SYNTH_TIMEOUT_REG': 0x33,
+            'VCO_TIMEOUT_REG': 0x34,
+            'ADC_CLK_REG': 0x35,
+            'ICP_OFFSET_REG': 0x36,
+            'SI_BAND_REG': 0x37,
+            'SI_VCO_REG': 0x38,
+            'SI_VTUNE_REG': 0x39,
+            'ADC_OFFSET_REG': 0x3A,
+            'SD_RESET_REG': 0x3D,
+            'CP_TMODE_REG': 0x3E,
+            'CLK1_DIV_LOW_REG': 0x3F,
+            'CLK1_DIV_HIGH_REG': 0x40,
+            'CLK2_DIV_REG': 0x41,
+            'TRM_RESD0_REG': 0x47,
+            'TRM_RESD1_REG': 0x52,
+            'VCO_DATA_LOW_REG': 0x6E,
+            'VCO_DATA_HIGH_REG': 0x6F,
+            'BIAS_SEL_X2_REG': 0x70,
+            'BIAS_SEL_X4_REG': 0x71,
+            'AUXOUT_REG': 0x72,
+            'LD_PD_ADC_REG': 0x73,
+            'LOCK_DETECT_REG': 0x7C}
+
+    def reg2addr(self, reg="CONFIG0_REG"):
         if reg in self.REGS:
             return self.REGS[reg]
         else:
-            print("%s: register %s not recognized." %(self.__class__.__name__,reg))
+            print("%s: register %s not recognized." %
+                  (self.__class__.__name__, reg))
             return -1
-        
+
     # Data array: 3 bytes.
     # byte[0] = opcode/addr high.
     # byte[1] = addr low.
     # byte[2] = register value (dummy for read).
-    def reg_rd(self,reg="CONFIG0_REG"):
+    def reg_rd(self, reg="CONFIG0_REG"):
         byte = []
-        
+
         # Read command.
         byte.append(self.cmd_rd)
-        
+
         # Address.
         addr = self.reg2addr(reg)
         byte.append(addr)
-        
+
         # Dummy byte for clocking data out.
         byte.append(0)
-        
+
         return byte
-    
-    def reg_wr(self,reg="CONFIG0_REG",val=0):
+
+    def reg_wr(self, reg="CONFIG0_REG", val=0):
         byte = []
-        
+
         # Write command.
         byte.append(self.cmd_wr)
-        
+
         # Address.
         addr = self.reg2addr(reg)
         byte.append(addr)
-        
+
         # Dummy byte for clocking data out.
         byte.append(val)
-        
+
         return byte
-    
+
     # Simple frequency setting function.
     # FRAC2 = 0 not used.
     # INT,FRAC1 sections are used.
     # All frequencies are in MHz.
     # Frequency must be in the range 4-8 GHz.
-    def set_freq(self,fin=6000):
+    def set_freq(self, fin=6000):
         # Structures for output.
         regs = {}
-        regs['INT'] = {'FULL':0, 'LOW':0, 'HIGH':0}
-        regs['FRAC1'] = {'FULL':0, 'LOW':0,'MID':0, 'HIGH':0, 'MSB':0}
-        
+        regs['INT'] = {'FULL': 0, 'LOW': 0, 'HIGH': 0}
+        regs['FRAC1'] = {'FULL': 0, 'LOW': 0, 'MID': 0, 'HIGH': 0, 'MSB': 0}
+
         # Sanity check.
-        if fin<4000:
-            print("%s: input frequency %d below the limit" %(self.__class__.__name__,fin))
+        if fin < 4000:
+            print("%s: input frequency %d below the limit" %
+                  (self.__class__.__name__, fin))
             return -1
-        elif fin>8000:
-            print("%s: input frequency %d above the limit" %(self.__class__.__name__,fin))
+        elif fin > 8000:
+            print("%s: input frequency %d above the limit" %
+                  (self.__class__.__name__, fin))
             return -1
-        
+
         Ndiv = fin/self.f_REF_in
-        
+
         # Integer part.
         int_ = int(np.floor(Ndiv))
         int_low = int_ & 0xff
         int_high = int_ >> 8
-        
+
         # Fractional part.
         frac_ = Ndiv - int_
         frac_ = int(np.floor(frac_*self.MOD1))
@@ -680,7 +698,7 @@ class ADF4372:
         frac_mid = (frac_ >> 8) & 0xff
         frac_high = (frac_ >> 16) & 0xff
         frac_msb = frac_ >> 24
-        
+
         # Write values into structure.
         regs['INT']['FULL'] = int_
         regs['INT']['LOW'] = int_low
@@ -690,704 +708,800 @@ class ADF4372:
         regs['FRAC1']['MID'] = frac_mid
         regs['FRAC1']['HIGH'] = frac_high
         regs['FRAC1']['MSB'] = frac_msb
-        
-        return regs    
-    
+
+        return regs
+
 # BIAS DAC chip AD5781.
+
+
 class AD5781:
     # Commands.
     cmd_wr = 0x0
     cmd_rd = 0x1
-    
+
     # Negative/Positive voltage references.
     VREFN = -10
     VREFP = 10
-    
+
     # Bits.
     B = 18
-    
+
     # Registers.
-    REGS = {'DAC_REG'   : 0x01,
-            'CTRL_REG'  : 0x02,
-            'CLEAR_REG' : 0x03,
-            'SOFT_REG'  : 0x04}
-    
+    REGS = {'DAC_REG': 0x01,
+            'CTRL_REG': 0x02,
+            'CLEAR_REG': 0x03,
+            'SOFT_REG': 0x04}
+
     # Register/address mapping.
-    def reg2addr(self,reg="DAC_REG"):
+    def reg2addr(self, reg="DAC_REG"):
         if reg in self.REGS:
             return self.REGS[reg]
         else:
-            print("%s: register %s not recognized." %(self.__class__.__name__,reg))
+            print("%s: register %s not recognized." %
+                  (self.__class__.__name__, reg))
             return -1
-        
-    def reg_rd(self,reg="DAC_REG"):
+
+    def reg_rd(self, reg="DAC_REG"):
         byte = []
-             
+
         # Address.
         addr = self.reg2addr(reg)
-        
+
         # R/W bit +  address (upper 4 bits).
         cmd = (self.cmd_rd << 3) | addr
         cmd = (cmd << 4)
         byte.append(cmd)
-        
+
         # Dummy bytes for completing the command.
         # NOTE: another full, 24-bit transaction is needed to clock the register out (may be all 0s).
         byte.append(0)
         byte.append(0)
-        
+
         return byte
-    
-    def reg_wr(self,reg="DAC_REG",val=0):
+
+    def reg_wr(self, reg="DAC_REG", val=0):
         byte = []
-        
+
         # Address.
         addr = self.reg2addr(reg)
-        
+
         # R/W bit +  address (upper 4 bits).
         cmd = (self.cmd_wr << 3) | addr
         cmd = (cmd << 4)
-        
+
         val_high = val >> 16
         val_mid = (val >> 8) & 0xff
         val_low = val & 0xff
-        
+
         # Append bytes.
         byte.append(cmd | val_high)
         byte.append(val_mid)
         byte.append(val_low)
-        
+
         return byte
-    
+
     # Compute register value for voltage setting.
-    def volt2reg(self,volt=0):
+    def volt2reg(self, volt=0):
         if volt < self.VREFN:
-            print("%s: %d V out of range." %(self.__class__.__name__,volt))
+            print("%s: %d V out of range." % (self.__class__.__name__, volt))
             return -1
         elif volt > self.VREFP:
-            print("%s: %d V out of range." %(self.__class__.__name__,volt))
+            print("%s: %d V out of range." % (self.__class__.__name__, volt))
             return -1
         else:
             Df = (2**self.B - 1)*(volt - self.VREFN)/(self.VREFP - self.VREFN)
-            
+
             # Shift by two as 2 lower bits are not used.
             Df = int(Df) << 2
-            
+
             return int(Df)
-        
+
 # Attenuator class: This class instantiates spi and PE43705 to simplify access to attenuator.
+
+
 class attenuator:
-   
+
     # Constructor.
     def __init__(self, spi_ip, ch=0, nch=3, le=[0], en_l="high", cs_t="pulse"):
         # PE43705.
         self.pe = PE43705(address=ch)
-        
+
         # SPI.
         self.spi = spi_ip
-        
+
         # Lath-enable.
         self.nch = nch
         self.le = le
         self.en_l = en_l
         self.cs_t = cs_t
-        
+
     # Set attenuation function.
-    def set_att(self,db):
+    def set_att(self, db):
         # Register value.
         reg = [self.pe.db2reg(db)]
-        
+
         # Write value using spi.
-        self.spi.send_receive_m(reg, len(reg), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(reg, len(reg), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
 # Power, Switch and Fan.
+
+
 class power_sw_fan:
-        
+
     # Constructor.
-    def __init__(self, spi_ip, nch=4, le=[0,1], en_l="low", cs_t=""):
+    def __init__(self, spi_ip, nch=4, le=[0, 1], en_l="low", cs_t=""):
         # MCP23S08.
         self.mcp = MCP23S08()
-        
+
         # SPI.
         self.spi = spi_ip
-        
+
         # CS.
         self.nch = nch
         self.le = le
         self.en_l = en_l
         self.cs_t = cs_t
-        
+
         # All CS to high value.
-        self.spi.reg_wr("SSR",0xff)
-        
+        self.spi.reg_wr("SSR", 0xff)
+
         # Set all bits as outputs.
         byte = self.mcp.reg_wr("IODIR_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Set all outputs to logic 1.
         byte = self.mcp.reg_wr("GPIO_REG", 0xff)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)        
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
     # Write bits.
     def bits_set(self, bits=[0]):
-        val=0
-        
+        val = 0
+
         # Read actual value.
         byte = self.mcp.reg_rd("GPIO_REG")
-        vals = self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+        vals = self.spi.send_receive_m(
+            byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
         val = int(vals[2])
-        
+
         # Set bits.
         for i in range(len(bits)):
             val |= (1 << bits[i])
-            
+
         # Set value to hardware.
         byte = self.mcp.reg_wr("GPIO_REG", val)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
     def bits_reset(self, bits=[0]):
-        val=0xff
-        
+        val = 0xff
+
         # Read actual value.
         byte = self.mcp.reg_rd("GPIO_REG")
-        vals = self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+        vals = self.spi.send_receive_m(
+            byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
         val = int(vals[2])
-        
+
         # Reset bits.
         for i in range(len(bits)):
             val &= ~(1 << bits[i])
-            
+
         # Set value to hardware.
         byte = self.mcp.reg_wr("GPIO_REG", val)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)       
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
 # LO Synthesis.
+
+
 class lo_synth:
-        
+
     # Constructor.
     def __init__(self, spi_ip, nch=2, le=[0], en_l="low", cs_t=""):
         # ADF4372.
         self.adf = ADF4372()
-        
+
         # SPI.
         self.spi = spi_ip
-        
+
         # CS.
         self.nch = nch
         self.le = le
         self.en_l = en_l
         self.cs_t = cs_t
-        
+
         # All CS to high value.
-        self.spi.reg_wr("SSR",0xff)
-           
+        self.spi.reg_wr("SSR", 0xff)
+
         # Write 0x00 to reg 0x73
         byte = self.adf.reg_wr("LD_PD_ADC_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x3a to reg 0x72
         byte = self.adf.reg_wr("AUXOUT_REG", 0x3A)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x60 to reg 0x71
         byte = self.adf.reg_wr("BIAS_SEL_X4_REG", 0x60)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0xe3 to reg 0x70
         byte = self.adf.reg_wr("BIAS_SEL_X2_REG", 0xE3)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0xf4 to reg 0x52
         byte = self.adf.reg_wr("TRM_RESD1_REG", 0xF4)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0xc0 to reg 0x47
         byte = self.adf.reg_wr("TRM_RESD0_REG", 0xC0)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x28 to reg 0x41
         byte = self.adf.reg_wr("CLK2_DIV_REG", 0x28)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x50 to reg 0x40
         byte = self.adf.reg_wr("CLK1_DIV_HIGH_REG", 0x50)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-            
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x80 to reg 0x3f
         byte = self.adf.reg_wr("CLK1_DIV_LOW_REG", 0x80)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x0c to reg 0x3e
         byte = self.adf.reg_wr("CP_TMODE_REG", 0x0C)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x3d
         byte = self.adf.reg_wr("SD_RESET_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x55 to reg 0x3a
         byte = self.adf.reg_wr("ADC_OFFSET_REG", 0x55)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x07 to reg 0x39
         byte = self.adf.reg_wr("SI_VTUNE_REG", 0x07)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x38
         byte = self.adf.reg_wr("SI_VCO_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x37
         byte = self.adf.reg_wr("SI_BAND_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-    
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x30 to reg 0x36
         byte = self.adf.reg_wr("ICP_OFFSET_REG", 0x30)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0xff to reg 0x35
         byte = self.adf.reg_wr("ADC_CLK_REG", 0xFF)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x86 to reg 0x34
         byte = self.adf.reg_wr("VCO_TIMEOUT_REG", 0x86)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x23 to reg 0x33
         byte = self.adf.reg_wr("SYNTH_TIMEOUT_REG", 0x23)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x04 to reg 0x32
         byte = self.adf.reg_wr("ADC_REG", 0x04)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x02 to reg 0x31
         byte = self.adf.reg_wr("TIMEOUT_REG", 0x02)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x34 to reg 0x30
         byte = self.adf.reg_wr("VCO_BAND_REG", 0x34)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x94 to reg 0x2f
         byte = self.adf.reg_wr("VCO_BIAS3_REG", 0x94)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x12 to reg 0x2e
         byte = self.adf.reg_wr("VCO_BIAS2_REG", 0x12)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x11 to reg 0x2d
         byte = self.adf.reg_wr("VCO_BIAS1_REG", 0x11)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x44 to reg 0x2c
         byte = self.adf.reg_wr("VCO_BIAS0_REG", 0x44)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x10 to reg 0x2b
         byte = self.adf.reg_wr("SD_REG", 0x10)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x2a
         byte = self.adf.reg_wr("CONFIG4_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x83 to reg 0x28
         byte = self.adf.reg_wr("LOCK_REG", 0x83)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0xcd to reg 0x27
         byte = self.adf.reg_wr("BLEED1_REG", 0xcd)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x2f to reg 0x26
         byte = self.adf.reg_wr("BLEED0_REG", 0x2F)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x07 to reg 0x25
         byte = self.adf.reg_wr("RFOUT_REG", 0x07)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x80 to reg 0x24
         byte = self.adf.reg_wr("RFDIV_REG", 0x80)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x23
         byte = self.adf.reg_wr("CONFIG3_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x22
         byte = self.adf.reg_wr("REF_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x14 to reg 0x20
         byte = self.adf.reg_wr("MUXOUT_REG", 0x14)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x01 to reg 0x1f
         byte = self.adf.reg_wr("RCNT_REG", 0x01)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x58 to reg 0x1e
         byte = self.adf.reg_wr("CONFIG2_REG", 0x58)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x1d
         byte = self.adf.reg_wr("PHASE_HIGH_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x1c
         byte = self.adf.reg_wr("PHASE_MID_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x1b
         byte = self.adf.reg_wr("PHASE_LOW_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x1a
         byte = self.adf.reg_wr("MOD2_HIGH_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x03 to reg 0x19
         byte = self.adf.reg_wr("MOD2_LOW_REG", 0x03)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x18
         byte = self.adf.reg_wr("FRAC2_HIGH_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x01 to reg 0x17 (holds MSB of FRAC1 on bit[0]).
         byte = self.adf.reg_wr("FRAC2_LOW_REG", 0x01)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x61 to reg 0x16
         byte = self.adf.reg_wr("FRAC1_HIGH_REG", 0x61)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x055 to reg 0x15
         byte = self.adf.reg_wr("FRAC1_MID_REG", 0x55)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x55 to reg 0x14
         byte = self.adf.reg_wr("FRAC1_LOW_REG", 0x55)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x40 to reg 0x12
         byte = self.adf.reg_wr("CAL_PRE_REG", 0x40)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x00 to reg 0x11
         byte = self.adf.reg_wr("INT_HIGH_REG", 0x00)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
         # Write 0x28 to reg 0x10
         byte = self.adf.reg_wr("INT_LOW_REG", 0x28)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
-    def reg_rd(self,reg="CONFIG0_REG"):
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
+    def reg_rd(self, reg="CONFIG0_REG"):
         # Byte array.
         byte = self.adf.reg_rd(reg)
-        
+
         # Execute read.
-        reg = self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        reg = self.spi.send_receive_m(
+            byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+
         return reg
-    
-    def reg_wr(self,reg="CONFIG0_REG",val=0):
+
+    def reg_wr(self, reg="CONFIG0_REG", val=0):
         # Byte array.
         byte = self.adf.reg_wr(reg, val)
-        
+
         # Execute write.
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
-    def set_freq(self,fin=6000):
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
+    def set_freq(self, fin=6000):
         # Get INT/FRAC register values.
         regs = self.adf.set_freq(fin)
-        
+
         # Check if it was successful.
         if regs == -1:
-            a=1
+            a = 1
         else:
             # Write FRAC1 register.
             # MSB
             byte = self.adf.reg_wr('FRAC2_LOW_REG', regs['FRAC1']['MSB'])
-            self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-            
+            self.spi.send_receive_m(
+                byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+
             # HIGH.
             byte = self.adf.reg_wr('FRAC1_HIGH_REG', regs['FRAC1']['HIGH'])
-            self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-            
+            self.spi.send_receive_m(
+                byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+
             # MID.
             byte = self.adf.reg_wr('FRAC1_MID_REG', regs['FRAC1']['MID'])
-            self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-            
+            self.spi.send_receive_m(
+                byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+
             # LOW.
             byte = self.adf.reg_wr('FRAC1_LOW_REG', regs['FRAC1']['LOW'])
-            self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-            
+            self.spi.send_receive_m(
+                byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+
             # Write INT register.
-            # HIGH.            
+            # HIGH.
             byte = self.adf.reg_wr('INT_HIGH_REG', regs['INT']['HIGH'])
-            self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-            
-            # LOW           
+            self.spi.send_receive_m(
+                byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+
+            # LOW
             byte = self.adf.reg_wr('INT_LOW_REG', regs['INT']['LOW'])
-            self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-            
+            self.spi.send_receive_m(
+                byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+
 # Bias dac.
+
+
 class dac_bias:
-        
+
     # Constructor.
-    def __init__(self, spi_ip, nch=4, le=[0,1], en_l="low", cs_t=""):
+    def __init__(self, spi_ip, nch=4, le=[0, 1], en_l="low", cs_t=""):
         # AD5791.
         self.ad = AD5781()
-        
+
         # SPI.
         self.spi = spi_ip
-        
+
         # CS.
         self.nch = nch
         self.le = le
         self.en_l = en_l
         self.cs_t = cs_t
-        
+
         # All CS to high value.
-        self.spi.reg_wr("SSR",0xff)
-        
+        self.spi.reg_wr("SSR", 0xff)
+
         # Initialize control register.
-        self.write(reg="CTRL_REG", val = 0x312)
-        
-    def read(self,reg="DAC_REG"):
+        self.write(reg="CTRL_REG", val=0x312)
+
+    def read(self, reg="DAC_REG"):
         # Read command.
         byte = self.ad.reg_rd(reg)
-        reg = self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        reg = self.spi.send_receive_m(
+            byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+
         # Another read with dummy data to allow clocking register out.
-        byte = [0,0,0]
-        reg = self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
+        byte = [0, 0, 0]
+        reg = self.spi.send_receive_m(
+            byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+
         return reg
-    
-    def write(self,reg="DAC_REG", val=0):
+
+    def write(self, reg="DAC_REG", val=0):
         # Write command.
         byte = self.ad.reg_wr(reg, val)
-        self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-        
-    def set_volt(self,volt=0):
+        self.spi.send_receive_m(byte, len(byte), self.nch,
+                                self.le, self.en_l, self.cs_t)
+
+    def set_volt(self, volt=0):
         # Convert volts to register value.
         val = self.ad.volt2reg(volt)
         self.write(reg="DAC_REG", val=val)
-        
+
 # Variable Gain Amp chip LMH6401.
+
+
 class LMH6401:
     # Commands.
     cmd_wr = 0x00
     cmd_rd = 0x80
-    
+
     # Registers.
-    REGS = {'REVID_REG'  : 0x00,
-            'PRODID_REG' : 0x01,
-            'GAIN_REG'   : 0x02,
-            'TGAIN_REG'  : 0x04,
-            'TFREQ_REG'  : 0x05}
-    
+    REGS = {'REVID_REG': 0x00,
+            'PRODID_REG': 0x01,
+            'GAIN_REG': 0x02,
+            'TGAIN_REG': 0x04,
+            'TFREQ_REG': 0x05}
+
     # Register/address mapping.
-    def reg2addr(self,reg="GAIN_REG"):
+    def reg2addr(self, reg="GAIN_REG"):
         if reg in self.REGS:
             return self.REGS[reg]
         else:
-            print("%s: register %s not recognized." %(self.__class__.__name__,reg))
+            print("%s: register %s not recognized." %
+                  (self.__class__.__name__, reg))
             return -1
-    
+
     # Data array: 2 bytes.
     # byte[0] = rw/address.
     # byte[1] = data.
-    def reg_rd(self,reg="GAIN_REG"):
+    def reg_rd(self, reg="GAIN_REG"):
         byte = []
-        
+
         # Address.
         addr = self.reg2addr(reg)
-        
+
         # Read command.
         cmd = self.cmd_rd | addr
         byte.append(cmd)
-        
+
         # Dummy byte for clocking data out.
         byte.append(0)
-        
+
         return byte
-    
-    def reg_wr(self,reg="GAIN_REG",val=0):
+
+    def reg_wr(self, reg="GAIN_REG", val=0):
         byte = []
-        
+
         # Address.
         addr = self.reg2addr(reg)
-        
+
         # Read command.
         cmd = self.cmd_wr | addr
         byte.append(cmd)
-        
+
         # Data.
         byte.append(val)
-        
+
         return byte
-    
+
 # Variable step amp class: This class instantiates spi and LMH6401 to simplify access to amplifier.
+
+
 class gain:
-    
+
     # Number of bits of gain setting.
     B = 6
-    
+
     # Minimum/maximum gain.
     Gmin = -6
     Gmax = 26
-   
+
     # Constructor.
-    def __init__(self, spi_ip, nch=4, le=[0,1,3], en_l="low", cs_t=""):
+    def __init__(self, spi_ip, nch=4, le=[0, 1, 3], en_l="low", cs_t=""):
         # LMH6401.
         self.lmh = LMH6401()
-        
+
         # SPI.
         self.spi = spi_ip
-        
+
         # Lath-enable.
         self.nch = nch
         self.le = le
         self.en_l = en_l
         self.cs_t = cs_t
-        
+
     # Set gain.
-    def set_gain(self,db):
+    def set_gain(self, db):
         # Sanity check.
         if db < self.Gmin:
-            print("%s: gain %f out of limits." %(self.__class__.__name__,db))
+            print("%s: gain %f out of limits." % (self.__class__.__name__, db))
         elif db > self.Gmax:
-            print("%s: gain %f out of limits." %(self.__class__.__name__,db))
+            print("%s: gain %f out of limits." % (self.__class__.__name__, db))
         else:
             # Convert gain to attenuation (register value).
             db_a = int(np.round(self.Gmax - db))
-            
+
             # Write command.
-            byte = self.lmh.reg_wr(reg="GAIN_REG", val = db_a)
-        
+            byte = self.lmh.reg_wr(reg="GAIN_REG", val=db_a)
+
             # Write value using spi.
-            self.spi.send_receive_m(byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
-            
+            self.spi.send_receive_m(
+                byte, len(byte), self.nch, self.le, self.en_l, self.cs_t)
+
 # Class to describe the ADC-RF channel chain.
+
+
 class adc_rf_ch():
     # Constructor.
-    def __init__(self, ch , switch_ip, buf_ip, attn_spi):
+    def __init__(self, ch, switch_ip, buf_ip, attn_spi):
         # Channel number.
         self.ch = ch
-        
+
         # AXIS Switch.
         self.switch = switch_ip
-        
+
         # MrBufferEt.
         self.buf = buf_ip
-        
+
         # Attenuator.
-        self.attn = attenuator(attn_spi, ch, nch=3, le=[0], en_l="high", cs_t="pulse")
-        
+        self.attn = attenuator(attn_spi, ch, nch=3, le=[
+                               0], en_l="high", cs_t="pulse")
+
         # Default to 30 dB attenuation.
         self.set_attn_db(30)
-            
+
     # Set attenuator.
     def set_attn_db(self, db=0):
         self.attn.set_att(db)
-        
+
     # Get data from buffer.
     def transfer(self):
         return self.buf.transfer()
-        
+
     # Capture data on buffer.
     def capture(self):
         # Route Switch to the right channel.
         self.buf.route(self.ch)
         time.sleep(0.1)
-        
+
         self.buf.enable()
         time.sleep(0.1)
         self.buf.disable()
-        
+
 # Class to describe the ADC-DC channel chain.
+
+
 class adc_dc_ch():
     # Constructor.
-    def __init__(self, ch , switch_ip, buf_ip, gain_spi):
+    def __init__(self, ch, switch_ip, buf_ip, gain_spi):
         # Channel number.
         self.ch = ch
-        
+
         # AXIS Switch.
         self.switch = switch_ip
-        
+
         # MrBufferEt.
         self.buf = buf_ip
-        
+
         # Variable Gain Amplifier.
         # LE.
-        le = [0,1,3]
+        le = [0, 1, 3]
         if ch == 4:
-            le = [0,1,3]
+            le = [0, 1, 3]
         elif ch == 5:
-            le = [1,3]
+            le = [1, 3]
         elif ch == 6:
-            le = [0,3]
+            le = [0, 3]
         elif ch == 7:
             le = [3]
         else:
-            print("%s: channel %d not valid for ADC-DC type" %(self.__class__.__name__,ch))
-            
+            print("%s: channel %d not valid for ADC-DC type" %
+                  (self.__class__.__name__, ch))
+
         self.gain = gain(gain_spi, nch=4, le=le, en_l="low", cs_t="")
-        
+
         # Default to 0 dB gain.
         self.set_gain_db(0)
-            
+
     # Set gain.
     def set_gain_db(self, db=0):
         self.gain.set_gain(db)
-        
+
     # Get data from buffer.
     def transfer(self):
         self.buf.transfer()
-        
+
     # Capture data on buffer.
     def capture(self):
         # Route Switch to the right channel.
         self.switch.sel(self.ch)
         time.sleep(0.1)
-        
+
         self.buf.enable()
         time.sleep(0.1)
         self.buf.disable()
-            
+
 # Class to describe the DAC channel chain.
+
+
 class dac_ch():
     # Constructor.
-    def __init__(self, ch , gen, gen_ctrl, rfsw, attn_spi):
+    def __init__(self, ch, gen, gen_ctrl, rfsw, attn_spi):
         # Channel number.
         self.ch = ch
-        
+
         # Signal Generator.
         self.gen = gen
-        
+
         # Signal Generator Control.
         self.gen_ctrl = gen_ctrl
-        
+
         # RF Input Switch.
         self.rfsw = rfsw
-        
+
         # Attenuators.
         self.attn = []
-        self.attn.append(attenuator(attn_spi, ch, nch=3, le=[1], en_l="high", cs_t="pulse"))        
-        self.attn.append(attenuator(attn_spi, ch, nch=3, le=[2], en_l="high", cs_t="pulse"))
-        
+        self.attn.append(attenuator(attn_spi, ch, nch=3,
+                                    le=[1], en_l="high", cs_t="pulse"))
+        self.attn.append(attenuator(attn_spi, ch, nch=3,
+                                    le=[2], en_l="high", cs_t="pulse"))
+
         # Default to 10 dB attenuation.
-        self.set_attn_db(0,10)
-        self.set_attn_db(1,10)
-        
+        self.set_attn_db(0, 10)
+        self.set_attn_db(1, 10)
+
     # Switch selection.
-    def rfsw_sel(self,sel="RF"):
+    def rfsw_sel(self, sel="RF"):
         if sel == "RF":
             # Set logic one.
             self.rfsw.bits_set(bits=[self.ch])
@@ -1395,38 +1509,41 @@ class dac_ch():
             # Set logic zero.
             self.rfsw.bits_reset(bits=[self.ch])
         else:
-            print("%s: selection %s not recoginzed." %(self.__class__.__name__,sel))
-            
+            print("%s: selection %s not recoginzed." %
+                  (self.__class__.__name__, sel))
+
     # Set attenuator.
     def set_attn_db(self, attn=0, db=0):
         if attn < len(self.attn):
             self.attn[attn].set_att(db)
         else:
-            print("%s: attenuator %d not in chain." %(self.__class__.__name__,attn))
-            
+            print("%s: attenuator %d not in chain." %
+                  (self.__class__.__name__, attn))
+
+
 class PfbSoc(Overlay):
     FREF_PLL = 204.8
-    
+
     # Constructor.
     def __init__(self, bitfile, init_clks=False, **kwargs):
         # Load bitstream.
         super().__init__(bitfile, **kwargs)
-        
+
         # Configure PLLs if requested.
         if init_clks:
             self.set_all_clks()
-        
+
         # Signal Generators.
         self.gen = []
         for i in range(8):
             gen = getattr(self, "axis_signal_gen_v3_{0}".format(i))
             gen.config(self.axi_dma_0,
-                    getattr(self, "axis_dds_mr_switch_{0}".format(i)),
-                    self.axis_switch_0,
-                    i,
-                    "DAC{0}".format(i))
+                       getattr(self, "axis_dds_mr_switch_{0}".format(i)),
+                       self.axis_switch_0,
+                       i,
+                       "DAC{0}".format(i))
             self.gen.append(gen)
-                
+
         # Signal Generators Control.
         self.gen_ctrl = []
         self.gen_ctrl.append(self.axis_signal_gen_v3_c_0)
@@ -1438,14 +1555,14 @@ class PfbSoc(Overlay):
         self.gen_ctrl.append(self.axis_signal_gen_v3_c_6)
         self.gen_ctrl.append(self.axis_signal_gen_v3_c_7)
         self.switch_gen = self.axis_dds_mr_switch_0
-        
+
         # Buffer for ADC channels.
         self.switch_bufs = self.axis_switch_1
         self.bufs = self.mr_buffer_et_0
         self.bufs.config(self.axi_dma_1, self.switch_bufs)
-        
-        #Enable 122.88 MHz Ref out on J108
-        #mylmk04208regs = [
+
+        # Enable 122.88 MHz Ref out on J108
+        # mylmk04208regs = [
         #    0x00160040, 0x00143200, 0x00143201, 0x00140322,
         #    0xC0140023, 0x40140024, 0x00140325, 0x01100006,
         #    0x01100007, 0x06010008, 0x55555549, 0x9102410A,
@@ -1453,10 +1570,10 @@ class PfbSoc(Overlay):
         #   0x8000800F, 0xC1550410, 0x00000058, 0x02C9C419,
         #    0x8FA8001A, 0x10001E1B, 0x0021201C, 0x0180033D,
         #    0x0200033E, 0x003F001F
-        #]
-        #xrfclk._write_lmk04208_regs(mylmk04208regs)
+        # ]
+        # xrfclk._write_lmk04208_regs(mylmk04208regs)
         xrfclk.set_ref_clks(lmk_freq=122.88128, lmx_freq=204.8)
-        
+
         # SPI used for Attenuators.
         self.attn_spi.config(
             lsb="lsb",
@@ -1466,7 +1583,7 @@ class PfbSoc(Overlay):
             txfifo="rst",
             mst="master",
             en="enable")
-        
+
         # SPI used for Power, Switch and Fan.
         self.psf_spi.config(
             lsb="msb",
@@ -1476,7 +1593,7 @@ class PfbSoc(Overlay):
             txfifo="rst",
             mst="master",
             en="enable")
-        
+
         # SPI used for the LO.
         self.lo_spi.config(
             lsb="msb",
@@ -1486,7 +1603,7 @@ class PfbSoc(Overlay):
             txfifo="rst",
             mst="master",
             en="enable")
-        
+
         # SPI used for DAC BIAS.
         self.dac_bias_spi.config(
             lsb="msb",
@@ -1497,60 +1614,80 @@ class PfbSoc(Overlay):
             mst="master",
             en="enable",
             cpha="invert")
-        
+
         # ADC/DAC power enable, DAC RF input switch.
-        self.adc_pwr = power_sw_fan(self.psf_spi, nch=4, le=[0,1,2,3], en_l="low", cs_t="")
-        self.dac_pwr = power_sw_fan(self.psf_spi, nch=4, le=[1,2,3], en_l="low", cs_t="")
-        self.dac_sw  = power_sw_fan(self.psf_spi, nch=4, le=[0,2,3], en_l="low", cs_t="")
-        
+        self.adc_pwr = power_sw_fan(self.psf_spi, nch=4, le=[
+                                    0, 1, 2, 3], en_l="low", cs_t="")
+        self.dac_pwr = power_sw_fan(self.psf_spi, nch=4, le=[
+                                    1, 2, 3], en_l="low", cs_t="")
+        self.dac_sw = power_sw_fan(self.psf_spi, nch=4, le=[
+                                   0, 2, 3], en_l="low", cs_t="")
+
         # LO Synthesizers.
         self.lo = []
-        self.lo.append(lo_synth(self.lo_spi, nch=2, le=[0], en_l="low", cs_t=""))
-        self.lo.append(lo_synth(self.lo_spi, nch=2, le=[1], en_l="low", cs_t=""))
-        
+        self.lo.append(lo_synth(self.lo_spi, nch=2,
+                                le=[0], en_l="low", cs_t=""))
+        self.lo.append(lo_synth(self.lo_spi, nch=2,
+                                le=[1], en_l="low", cs_t=""))
+
         # DAC BIAS.
         self.dac_bias = []
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[0,1,2,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[1,2,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[0,2,3], en_l="low", cs_t="") )                           
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[2,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[0,1,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[1,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[0,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[3], en_l="low", cs_t=""))
-        
+        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[
+                             0, 1, 2, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[
+                             1, 2, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[
+                             0, 2, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(
+            dac_bias(self.dac_bias_spi, nch=4, le=[2, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[
+                             0, 1, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(
+            dac_bias(self.dac_bias_spi, nch=4, le=[1, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(
+            dac_bias(self.dac_bias_spi, nch=4, le=[0, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(
+            dac_bias(self.dac_bias_spi, nch=4, le=[3], en_l="low", cs_t=""))
+
         # ADC channels.
         self.adcs = []
         for ii in range(4):
-            self.adcs.append(adc_rf_ch(ii, self.switch_bufs, self.bufs, self.attn_spi))
-            
+            self.adcs.append(
+                adc_rf_ch(ii, self.switch_bufs, self.bufs, self.attn_spi))
+
         for ii in range(4):
-            self.adcs.append(adc_dc_ch(4+ii, self.switch_bufs, self.bufs, self.psf_spi))
-        
+            self.adcs.append(
+                adc_dc_ch(4+ii, self.switch_bufs, self.bufs, self.psf_spi))
+
         # DAC channels.
         self.dacs = []
-        for ii in range(8):            
-            self.dacs.append(dac_ch(ii , self.gen[ii], self.gen_ctrl[ii], self.dac_sw, self.attn_spi))        
-        
+        for ii in range(8):
+            self.dacs.append(
+                dac_ch(ii, self.gen[ii], self.gen_ctrl[ii], self.dac_sw, self.attn_spi))
+
     def set_all_clks(self):
        # xrfclk.set_all_ref_clks(self.__class__.FREF_PLL)
         xrfclk.set_ref_clks(lmk_freq=122.88128, lmx_freq=204.8)
+
 
 class RFQickSoc(QickSoc):
     """
     Overrides the __init__ method of QickSoc in order to add the RF board drivers.
     Otherwise supports all the QickSoc functionality.
     """
-    def __init__(self, bitfile=None, force_init_clks=False,ignore_version=True, **kwargs):
+
+    def __init__(self, bitfile=None, force_init_clks=False, ignore_version=True, **kwargs):
         """
         Constructor method
         """
         # Load bitstream. We read the bitstream configuration from the HWH file, but we don't program the FPGA yet.
         # We need to program the clocks first.
-        if bitfile==None:
-            Overlay.__init__(self, bitfile_path(), ignore_version=ignore_version, download=False, **kwargs)
+        if bitfile == None:
+            Overlay.__init__(self, bitfile_path(
+            ), ignore_version=ignore_version, download=False, **kwargs)
         else:
-            Overlay.__init__(self, bitfile, ignore_version=ignore_version, download=False, **kwargs)
+            Overlay.__init__(
+                self, bitfile, ignore_version=ignore_version, download=False, **kwargs)
 
         # Initialize the configuration
         self._cfg = {}
@@ -1559,7 +1696,8 @@ class RFQickSoc(QickSoc):
         self['board'] = os.environ["BOARD"]
 
         # Read the config to get a list of enabled ADCs and DACs, and the sampling frequencies.
-        self.list_rf_blocks(self.ip_dict['usp_rf_data_converter_0']['parameters'])
+        self.list_rf_blocks(
+            self.ip_dict['usp_rf_data_converter_0']['parameters'])
 
         self.config_clocks(force_init_clks)
 
@@ -1596,7 +1734,7 @@ class RFQickSoc(QickSoc):
             txfifo="rst",
             mst="master",
             en="enable")
-        
+
         # SPI used for Power, Switch and Fan.
         self.psf_spi.config(
             lsb="msb",
@@ -1606,7 +1744,7 @@ class RFQickSoc(QickSoc):
             txfifo="rst",
             mst="master",
             en="enable")
-        
+
         # SPI used for the LO.
         self.lo_spi.config(
             lsb="msb",
@@ -1616,7 +1754,7 @@ class RFQickSoc(QickSoc):
             txfifo="rst",
             mst="master",
             en="enable")
-        
+
         # SPI used for DAC BIAS.
         self.dac_bias_spi.config(
             lsb="msb",
@@ -1627,25 +1765,37 @@ class RFQickSoc(QickSoc):
             mst="master",
             en="enable",
             cpha="invert")
-        
+
         # ADC/DAC power enable, DAC RF input switch.
-        self.adc_pwr = power_sw_fan(self.psf_spi, nch=4, le=[0,1,2,3], en_l="low", cs_t="")
-        self.dac_pwr = power_sw_fan(self.psf_spi, nch=4, le=[1,2,3], en_l="low", cs_t="")
-        self.dac_sw  = power_sw_fan(self.psf_spi, nch=4, le=[0,2,3], en_l="low", cs_t="")
-        
+        self.adc_pwr = power_sw_fan(self.psf_spi, nch=4, le=[
+                                    0, 1, 2, 3], en_l="low", cs_t="")
+        self.dac_pwr = power_sw_fan(self.psf_spi, nch=4, le=[
+                                    1, 2, 3], en_l="low", cs_t="")
+        self.dac_sw = power_sw_fan(self.psf_spi, nch=4, le=[
+                                   0, 2, 3], en_l="low", cs_t="")
+
         # LO Synthesizers.
         self.lo = []
-        self.lo.append(lo_synth(self.lo_spi, nch=2, le=[0], en_l="low", cs_t=""))
-        self.lo.append(lo_synth(self.lo_spi, nch=2, le=[1], en_l="low", cs_t=""))
-        
+        self.lo.append(lo_synth(self.lo_spi, nch=2,
+                                le=[0], en_l="low", cs_t=""))
+        self.lo.append(lo_synth(self.lo_spi, nch=2,
+                                le=[1], en_l="low", cs_t=""))
+
         # DAC BIAS.
         self.dac_bias = []
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[0,1,2,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[1,2,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[0,2,3], en_l="low", cs_t="") )                           
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[2,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[0,1,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[1,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[0,3], en_l="low", cs_t=""))
-        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[3], en_l="low", cs_t=""))
-        
+        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[
+                             0, 1, 2, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[
+                             1, 2, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[
+                             0, 2, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(
+            dac_bias(self.dac_bias_spi, nch=4, le=[2, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(dac_bias(self.dac_bias_spi, nch=4, le=[
+                             0, 1, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(
+            dac_bias(self.dac_bias_spi, nch=4, le=[1, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(
+            dac_bias(self.dac_bias_spi, nch=4, le=[0, 3], en_l="low", cs_t=""))
+        self.dac_bias.append(
+            dac_bias(self.dac_bias_spi, nch=4, le=[3], en_l="low", cs_t=""))

--- a/qick_lib/qick/streamer.py
+++ b/qick_lib/qick/streamer.py
@@ -1,8 +1,7 @@
-import numpy as np
 from multiprocessing import Process, Queue, Event
 import queue
 import time
-import os
+import numpy as np
 
 
 class DataStreamer():
@@ -21,7 +20,7 @@ class DataStreamer():
         # Process object for the streaming readout.
         self.readout_process = None
 
-    def start_readout(self, total_count, counter_addr=1, ch_list=[0, 1], reads_per_count=1):
+    def start_readout(self, total_count, counter_addr=1, ch_list=None, reads_per_count=1):
         """
         Start a streaming readout of the average buffers.
 
@@ -34,6 +33,8 @@ class DataStreamer():
         :param reads_per_count: Number of data points to expect per counter increment
         :type reads_per_count: int
         """
+        if ch_list is None:
+            ch_list = [0, 1]
 
         # if there's still a readout process running, stop it
         if self.readout_alive():


### PR DESCRIPTION
Some major changes to the software interface here, probably not fully complete. This will require changes to existing programs, but it was necessary in order to support the new firmware blocks.

* QickProgram now has `declare_readout()` and `declare_gen()` methods that are meant to make more explicit the process of setting up the generator and readout channels you intend to use in a program.
* Channel numbers strictly follow the indices printed in QickSoc.description() - meaning generator channels are now 0-indexed, not 1-indexed.
* The process for defining and firing a pulse has changed - previously you would call `add_pulse()` to save a waveform, optionally `pulse(play=False)` to write registers, and `pulse(play=True)` to fire the pulse; now writing registers is mandatory and done with `set_pulse_registers()`.

The following firmware blocks are now supported:
* AxisSignalGenV5: similar to the existing AxisSignalGenV4, but with some optimizations
* AxisSgInt4V1: interpolated signal generator, uses much less waveform memory
* AxisSgMux4V1: frequency-muxed signal generator, can only drive full-power const pulses but can drive 4 frequencies at once
* AxisConstantIQ: drives a constant sine wave on a DAC output
* AxisPFBReadoutV2: frequency-muxed readout

Not done yet, will happen next:
* update demo notebooks
* update docstrings