### PR TITLE
parser updates to support qick-amo firmware

### DIFF
--- a/qick_lib/qick/helpers.py
+++ b/qick_lib/qick/helpers.py
@@ -91,12 +91,16 @@ class BusParser:
         This is essentially a copy of the HWH parser's match_nets() and match_pins(),
         but working on buses instead of signals.
 
+        In addition, there's a map from module names to module types.
+
         :param parser: HWH parser object (from Overlay.parser)
         """
         self.nets = {}
         self.pins = {}
+        self.mod2type = {}
         for module in parser.root.findall('./MODULES/MODULE'):
             fullpath = module.get('FULLNAME').lstrip('/')
+            self.mod2type[fullpath] = module.get('MODTYPE')
             for bus in module.findall('./BUSINTERFACES/BUSINTERFACE'):
                 port = fullpath + '/' + bus.get('NAME')
                 busname = bus.get('BUSNAME')


### PR DESCRIPTION
The qick-amo firmware has more register slice and clock converter blocks, and they are named differently. Had to make the parser smarter to handle this:
* jump through multiple slices/converters in a row if necessary
* check the block type using the actual IP type, not by string-matching the block name