### PR TITLE
speedup

### DIFF
--- a/qick_lib/qick/averager_program.py
+++ b/qick_lib/qick/averager_program.py
@@ -124,8 +124,8 @@ class AveragerProgram(QickProgram):
         streamer = soc.streamer
         streamer.start_readout(total_count, counter_addr=1,
                                ch_list=list(self.ro_chs))
-        while streamer.readout_alive():
-            new_data = streamer.poll_data()
+        while count<total_count:
+            new_data = streamer.poll_data(max_expected=min(10000, total_count-count))
             for d, s in new_data:
                 new_points = d.shape[2]
                 d_buf[:, :, count:count+new_points] = d
@@ -467,8 +467,8 @@ class RAveragerProgram(QickProgram):
         with tqdm(total=total_count, disable=not progress) as pbar:
             streamer.start_readout(total_count, counter_addr=1, ch_list=list(
                 self.ro_chs), reads_per_count=readouts_per_experiment)
-            while streamer.readout_alive():
-                new_data = streamer.poll_data()
+            while count<total_count:
+                new_data = streamer.poll_data(max_expected=min(10000, total_count-count))
                 for d, s in new_data:
                     new_points = d.shape[2]
                     d_buf[:, :, count:count+new_points] = d

--- a/qick_lib/qick/averager_program.py
+++ b/qick_lib/qick/averager_program.py
@@ -125,7 +125,7 @@ class AveragerProgram(QickProgram):
         streamer.start_readout(total_count, counter_addr=1,
                                ch_list=list(self.ro_chs))
         while count<total_count:
-            new_data = streamer.poll_data(max_expected=min(10000, total_count-count))
+            new_data = streamer.poll_data()
             for d, s in new_data:
                 new_points = d.shape[2]
                 d_buf[:, :, count:count+new_points] = d
@@ -468,7 +468,7 @@ class RAveragerProgram(QickProgram):
             streamer.start_readout(total_count, counter_addr=1, ch_list=list(
                 self.ro_chs), reads_per_count=readouts_per_experiment)
             while count<total_count:
-                new_data = streamer.poll_data(max_expected=min(10000, total_count-count))
+                new_data = streamer.poll_data()
                 for d, s in new_data:
                     new_points = d.shape[2]
                     d_buf[:, :, count:count+new_points] = d

--- a/qick_lib/qick/averager_program.py
+++ b/qick_lib/qick/averager_program.py
@@ -116,28 +116,27 @@ class AveragerProgram(QickProgram):
         reps = self.cfg['reps']
         total_count = reps
         count = 0
-        t = tqdm(total=total_count, disable=not progress)  # progress bar
+        n_ro = len(self.ro_chs)
 
-        d_buf = np.zeros((len(self.ro_chs), 2, total_count))
-        stats_list = []
-
+        d_buf = np.zeros((n_ro, 2, total_count))
+        self.stats = []
         streamer = soc.streamer
-        streamer.start_readout(total_count, counter_addr=1,
-                               ch_list=list(self.ro_chs))
-        while count<total_count:
-            new_data = streamer.poll_data()
-            for d, s in new_data:
-                new_points = d.shape[2]
-                d_buf[:, :, count:count+new_points] = d
-                count += new_points
-                stats_list.append(s)
-                t.update(new_points)
-        t.close()
-        self.stats = stats_list
+
+        with tqdm(total=total_count, disable=not progress) as pbar:
+            streamer.start_readout(total_count, counter_addr=1,
+                                   ch_list=list(self.ro_chs))
+            while count<total_count:
+                new_data = streamer.poll_data()
+                for d, s in new_data:
+                    new_points = d.shape[2]
+                    d_buf[:, :, count:count+new_points] = d
+                    count += new_points
+                    self.stats.append(s)
+                    pbar.update(new_points)
 
         # reformat the data into separate I and Q arrays
-        di_buf = np.stack([d_buf[i][0] for i in range(len(self.ro_chs))])
-        dq_buf = np.stack([d_buf[i][1] for i in range(len(self.ro_chs))])
+        di_buf = d_buf[:,0,:]
+        dq_buf = d_buf[:,1,:]
 
         # save results to class in case you want to look at it later or for analysis
         self.di_buf = di_buf
@@ -147,8 +146,8 @@ class AveragerProgram(QickProgram):
             self.shots = self.get_single_shots(
                 di_buf, dq_buf, threshold, angle)
 
-        avg_di = np.zeros((len(self.ro_chs), len(save_experiments)))
-        avg_dq = np.zeros((len(self.ro_chs), len(save_experiments)))
+        avg_di = np.zeros((n_ro, len(save_experiments)))
+        avg_dq = np.zeros((n_ro, len(save_experiments)))
 
         for nn, ii in enumerate(save_experiments):
             for i_ch, (ch, ro) in enumerate(self.ro_chs.items()):
@@ -457,12 +456,13 @@ class RAveragerProgram(QickProgram):
 
         reps, expts = self.cfg['reps'], self.cfg['expts']
 
-        count = 0
         total_count = reps*expts*readouts_per_experiment
+        count = 0
+        n_ro = len(self.ro_chs)
 
-        d_buf = np.zeros((len(self.ro_chs), 2, total_count))
+        d_buf = np.zeros((n_ro, 2, total_count))
+        self.stats = []
         streamer = soc.streamer
-        stats_list = []
 
         with tqdm(total=total_count, disable=not progress) as pbar:
             streamer.start_readout(total_count, counter_addr=1, ch_list=list(
@@ -473,13 +473,12 @@ class RAveragerProgram(QickProgram):
                     new_points = d.shape[2]
                     d_buf[:, :, count:count+new_points] = d
                     count += new_points
-                    stats_list.append(s)
+                    self.stats.append(s)
                     pbar.update(new_points)
-            self.stats = stats_list
 
         # reformat the data into separate I and Q arrays
-        di_buf = np.stack([d_buf[i][0] for i in range(len(self.ro_chs))])
-        dq_buf = np.stack([d_buf[i][1] for i in range(len(self.ro_chs))])
+        di_buf = d_buf[:,0,:]
+        dq_buf = d_buf[:,1,:]
 
         # save results to class in case you want to look at it later or for analysis
         self.di_buf = di_buf
@@ -491,8 +490,8 @@ class RAveragerProgram(QickProgram):
 
         expt_pts = self.get_expt_pts()
 
-        avg_di = np.zeros((len(self.ro_chs), len(save_experiments), expts))
-        avg_dq = np.zeros((len(self.ro_chs), len(save_experiments), expts))
+        avg_di = np.zeros((n_ro, len(save_experiments), expts))
+        avg_dq = np.zeros((n_ro, len(save_experiments), expts))
 
         for nn, ii in enumerate(save_experiments):
             for i_ch, (ch, ro) in enumerate(self.ro_chs.items()):

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1277,35 +1277,15 @@ class AxisTProc64x32_x8(SocIp):
         # Binary file format.
         if fmt == "bin":
             # Read binary file from disk.
-            fd = open(prog, "r")
-
-            # Write memory.
-            addr = 0
-            for line in fd:
-                line.strip("\r\n")
-                dec = int(line, 2)
-                dec_low = dec & 0xffffffff
-                dec_high = dec >> 32
-                self.mem.write(addr, value=int(dec_low))
-                addr = addr + 4
-                self.mem.write(addr, value=int(dec_high))
-                addr = addr + 4
+            with open(prog, "r") as fd:
+                progList = [int(line, 2) for line in fd]
 
         # Asm file.
         elif fmt == "asm":
             # Compile program.
             progList = parse_to_bin(prog)
 
-            # Load Program Memory.
-            addr = 0
-            for dec in progList:
-                #print ("@" + str(addr) + ": " + str(dec))
-                dec_low = dec & 0xffffffff
-                dec_high = dec >> 32
-                self.mem.write(addr, value=int(dec_low))
-                addr = addr + 4
-                self.mem.write(addr, value=int(dec_high))
-                addr = addr + 4
+        self.load_bin_program(progList)
 
     def single_read(self, addr):
         """

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1259,11 +1259,10 @@ class AxisTProc64x32_x8(SocIp):
         if reset:
             self.reset()
 
-        for ii, inst in enumerate(binprog):
-            dec_low = inst & 0xffffffff
-            dec_high = inst >> 32
-            self.mem.write(8*ii, value=int(dec_low))
-            self.mem.write(4*(2*ii+1), value=int(dec_high))
+        # cast the program words to 64-bit uints
+        p = np.array(binprog, dtype=np.uint64)
+        # reshape to 32-bit uints to match the program memory, and do a fast copy
+        np.copyto(self.mem.mmio.array[:2*len(p)], np.frombuffer(p, np.uint32))
 
     def load_program(self, prog="prog.asm", fmt="asm"):
         """

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -154,6 +154,20 @@ class QickConfig():
         k_i = np.round(f_round*(2**thisch['b_dds'])/thisch['fs'])
         return np.int64(k_i)
 
+    def int2freq(self, r, thisch):
+        """
+        Converts register value to MHz.
+        This method works for both DACs and ADCs.
+
+        :param r: register value
+        :type r: int
+        :param thisch: config dict for the channel you're configuring
+        :type thisch: dict
+        :return: Re-formatted frequency (MHz)
+        :rtype: float
+        """
+        return r * thisch['fs'] / 2**thisch['b_dds']
+
     def freq2reg(self, f, gen_ch=0, ro_ch=None):
         """
         Converts frequency in MHz to tProc DAC register value.
@@ -722,7 +736,7 @@ class QickProgram:
         elif gen_type == 'axis_sg_mux4_v1':
             if mask is None:
                 raise RuntimeError("mask must be specified for mux generator")
-            if any([x is not None for x in [stdysel, phrst, freq, phase, gain]]):
+            if any([x is not None for x in [stdysel, phrst, mode, freq, phase, gain]]):
                 raise RuntimeError(gen_type, "does not support specified options")
             p.safe_regwi(rp, r_e, length, f'length = {length}')
             val_mask = 0
@@ -921,7 +935,7 @@ class QickProgram:
             if t == 'auto':
                 t = int(self.dac_ts[ch])
             elif t < self.dac_ts[ch]:
-                print("Pulse time %d appears to conflict with previous pulse ending at %f?"%(t, dac_ts[ch]))
+                print("warning: pulse time %d appears to conflict with previous pulse ending at %f?"%(t, self.dac_ts[ch]))
             # convert from generator clock to tProc clock
             pulse_length = last_pulse['length']
             pulse_length *= self.soccfg['fs_proc']/self.soccfg['gens'][ch]['f_fabric']

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -65,11 +65,9 @@ class QickConfig():
             lines.append("\t\tmaxlen %d (avg) %d (decimated), trigger %d, tProc input %d" % (
                 readout['avg_maxlen'], readout['buf_maxlen'], readout['trigger_bit'], readout['tproc_ch']))
 
-        if hasattr(self, 'tproc'):  # this is a QickSoc
-            lines.append("\n\ttProc: %d words program memory, %d words data memory" % (
-                2**self.tproc.PMEM_N, 2**self.tproc.DMEM_N))
-            lines.append("\t\tprogram RAM: %d bytes" %
-                         (self.tproc.mem.mmio.length))
+        tproc = self['tprocs'][0]
+        lines.append("\n\ttProc: %d words program memory, %d words data memory" %
+                (tproc['pmem_size'], tproc['dmem_size']))
 
         return "\nQICK configuration:\n"+"\n".join(lines)
 
@@ -1220,14 +1218,14 @@ class QickProgram:
         """
         return [self.compile_instruction(inst, debug=debug) for inst in self.prog_list]
 
-    def load_program(self, soc, debug=False):
+    def load_program(self, soc, debug=False, reset=False):
         """
         Load the compiled program into the tProcessor.
 
         :param debug: If True, debug mode is on
         :type debug: bool
         """
-        soc.tproc.load_bin_program(self.compile(debug=debug))
+        soc.tproc.load_bin_program(self.compile(debug=debug), reset=reset)
 
     def get_mode_code(self, length, mode=None, outsel=None, stdysel=None, phrst=None):
         """

--- a/qick_lib/qick/streamer.py
+++ b/qick_lib/qick/streamer.py
@@ -5,7 +5,8 @@ import time
 import numpy as np
 
 # This code originally used Process not Thread.
-# Process is slower (Process.start() is ~100 ms, Thread.start() is a few ms).
+# Process is much slower to start (Process.start() is ~100 ms, Thread.start() is a few ms)
+# The process-safe versions of Queue and Event are also significantly slower.
 # On the other hand, CPU-bound Python threads can't run in parallel ("global interpreter lock").
 # The overall problem is not CPU-bound - we should always be limited by tProc execution.
 # In the worst case where the tProc is running fast, we should actually be waiting for IO a lot (due to the DMA).

--- a/qick_lib/qick/streamer.py
+++ b/qick_lib/qick/streamer.py
@@ -195,8 +195,6 @@ class DataStreamer():
                         # don't trim if this is the last read of the run
                         if count < last_count:
                             length -= length % 2
-                        #else:
-                        #    time.sleep(0.0001)
 
                         # buffer for each channel
                         d_buf = np.zeros((len(ch_list), 2, length))


### PR DESCRIPTION
Various changes to reduce overheads when running short AveragerPrograms - the overhead is now <4 ms, and at least a third of that is Python stuff (creating and compiling the AveragerProgram) that is hard to reduce.

* use a thread instead of a process for the streamer.py worker, and don't restart it for every program
* don't use timeouts in poll_data
* use numpy array ops to load the compiled program
* read/write the memory-mapped MMIO array directly for register accesses, instead of using mmio.read()/write()
* by default, don't reset the tProc (reset_gens still does a tProc reset)

Also, fixed #29.