### PR TITLE
reduce pyro overhead

### DIFF
--- a/qick_demos/00_Send_receive_pulse.ipynb
+++ b/qick_demos/00_Send_receive_pulse.ipynb
@@ -172,7 +172,7 @@
     "Each signal generator has an internal waveform memory, which stores the I/Q data for the pulse envelope. Multiple waveforms can be stored in the same signal generator, and a single waveform can be used for different pulses (e.g. a Gaussian waveform can be used for Gaussian pulses and the ramp-up/ramp-down of flat-top pulses with different flat-top duration, each with its own gain and carrier frequency).\n",
     "\n",
     "`add_pulse(ch, name, idata, qdata)` writes an arbitrary waveform to the specified channel's waveform memory. \n",
-    "`add_gauss(ch, name, length, sigma)`, `add_triangle(ch, name, length)`, and `add_DRAG(ch, name, length, sigma, delta, alpha)` write commonly-used standard pulse waveforms. The name is used in the next step.\n",
+    "`add_gauss(ch, name, length, sigma)`, `add_triangle(ch, name, length)`, and `add_DRAG(ch, name, length, sigma, delta, alpha)` write commonly-used standard pulse waveforms, with duration units of fabric clock cycles. The name is used in the next step.\n",
     "\n",
     "#### Setting registers\n",
     "There are a lot of parameters that need to be specified when playing a pulse - more than can be specified inline in a tProcessor instruction. So all the parameters must be written to registers first, and when we fire the pulse we just tell the tProcessor which registers to read.\n",

--- a/qick_demos/01_Phase_coherent_readout.ipynb
+++ b/qick_demos/01_Phase_coherent_readout.ipynb
@@ -54,6 +54,7 @@
    "source": [
     "# Import the QICK drivers and auxiliary libraries\n",
     "from qick import *\n",
+    "from qick.parser import load_program\n",
     "%pylab inline"
    ]
   },
@@ -326,8 +327,7 @@
     "    soc.load_pulse_data(ch=ch,idata=xg_i, qdata=xg_q,addr=0)\n",
     "\n",
     "# Load program.\n",
-    "soc.tproc.load_bin_program(parser.parse_to_bin(\"01_phase_calibration.asm\"))\n",
-    "# soc.tproc.load_program(\"01_phase_calibration.asm\")\n",
+    "load_program(soc, prog=\"01_phase_calibration.asm\")\n",
     "\n",
     "# Output phase.\n",
     "fi0 = 0\n",
@@ -456,7 +456,7 @@
     "\n",
     "print(prog)\n",
     "\n",
-    "soc.tproc.load_bin_program(prog.compile())\n",
+    "prog.load_program(soc)\n",
     "\n",
     "# Constant, real envelope.\n",
     "# The length must be at least 16 times the nsamp parameter passed to the signal generators.\n",

--- a/qick_demos/02_Sweeping_variables.ipynb
+++ b/qick_demos/02_Sweeping_variables.ipynb
@@ -48,6 +48,7 @@
    "source": [
     "# Import the QICK drivers and auxiliary libraries\n",
     "from qick import *\n",
+    "from tqdm.notebook import tqdm\n",
     "%pylab inline"
    ]
   },
@@ -129,7 +130,7 @@
     "        self.declare_readout(ch=cfg[\"ro_ch\"], length=self.cfg[\"readout_length\"],\n",
     "                             freq=self.cfg[\"pulse_freq\"], gen_ch=cfg[\"res_ch\"])\n",
     "        \n",
-    "        freq=self.freq2reg(cfg[\"pulse_freq\"], gen_ch=cfg[\"gen_ch\"], ro_ch=cfg[\"ro_ch\"])  # convert frequency to dac frequency (ensuring it is an available adc frequency)\n",
+    "        freq=self.freq2reg(cfg[\"pulse_freq\"], gen_ch=cfg[\"res_ch\"], ro_ch=cfg[\"ro_ch\"])  # convert frequency to dac frequency (ensuring it is an available adc frequency)\n",
     "        self.set_pulse_registers(ch=cfg[\"res_ch\"], style=\"const\", freq=freq, phase=0, gain=cfg[\"start\"], \n",
     "                                 length=cfg[\"length\"])\n",
     "        self.synci(200)  # give processor some time to configure pulses\n",
@@ -176,7 +177,7 @@
     "       }\n",
     "\n",
     "prog =SweepProgram(soccfg, config)\n",
-    "expt_pts, avgi, avgq = prog.acquire(soc, load_pulses=True)"
+    "expt_pts, avgi, avgq = prog.acquire(soc, load_pulses=True, progress=True)"
    ]
   },
   {
@@ -243,7 +244,7 @@
     "gpts=sweep_cfg[\"start\"] + sweep_cfg[\"step\"]*np.arange(sweep_cfg[\"expts\"])\n",
     "\n",
     "results=[]\n",
-    "for g in gpts:\n",
+    "for g in tqdm(gpts):\n",
     "    config[\"pulse_gain\"]=int(g)\n",
     "    prog =LoopbackProgram(soccfg, config)\n",
     "    results.append(prog.acquire(soc, load_pulses=True))\n",

--- a/qick_lib/qick/averager_program.py
+++ b/qick_lib/qick/averager_program.py
@@ -111,7 +111,7 @@ class AveragerProgram(QickProgram):
         self.load_program(soc, debug=debug)
 
         # configure tproc for internal/external start
-        soc.tproc.start_src(start_src)
+        soc.start_src(start_src)
 
         reps = self.cfg['reps']
         total_count = reps
@@ -291,9 +291,9 @@ class AveragerProgram(QickProgram):
         self.load_program(soc, debug=debug)
 
         # configure tproc for internal/external start
-        soc.tproc.start_src(start_src)
-
         tproc = soc.tproc
+
+        soc.start_src(start_src)
         # for each soft average, run and acquire decimated data
         for ii in tqdm(range(soft_avgs), disable=not progress):
 
@@ -452,7 +452,7 @@ class RAveragerProgram(QickProgram):
         self.load_program(soc, debug=debug)
 
         # configure tproc for internal/external start
-        soc.tproc.start_src(start_src)
+        soc.start_src(start_src)
 
         reps, expts = self.cfg['reps'], self.cfg['expts']
 

--- a/qick_lib/qick/averager_program.py
+++ b/qick_lib/qick/averager_program.py
@@ -120,13 +120,12 @@ class AveragerProgram(QickProgram):
 
         d_buf = np.zeros((n_ro, 2, total_count))
         self.stats = []
-        streamer = soc.streamer
 
         with tqdm(total=total_count, disable=not progress) as pbar:
-            streamer.start_readout(total_count, counter_addr=1,
+            soc.start_readout(total_count, counter_addr=1,
                                    ch_list=list(self.ro_chs))
             while count<total_count:
-                new_data = streamer.poll_data()
+                new_data = soc.poll_data()
                 for d, s in new_data:
                     new_points = d.shape[2]
                     d_buf[:, :, count:count+new_points] = d
@@ -462,13 +461,12 @@ class RAveragerProgram(QickProgram):
 
         d_buf = np.zeros((n_ro, 2, total_count))
         self.stats = []
-        streamer = soc.streamer
 
         with tqdm(total=total_count, disable=not progress) as pbar:
-            streamer.start_readout(total_count, counter_addr=1, ch_list=list(
+            soc.start_readout(total_count, counter_addr=1, ch_list=list(
                 self.ro_chs), reads_per_count=readouts_per_experiment)
             while count<total_count:
-                new_data = streamer.poll_data()
+                new_data = soc.poll_data()
                 for d, s in new_data:
                     new_points = d.shape[2]
                     d_buf[:, :, count:count+new_points] = d

--- a/qick_lib/qick/parser.py
+++ b/qick_lib/qick/parser.py
@@ -890,3 +890,27 @@ def parse_to_bin(path):
     """
     p = parse_prog(path)
     return [int(p[i], 2) for i in p]
+
+def load_program(soc, prog="prog.asm", fmt="asm"):
+    """
+    Loads tProc program. If asm program, it compiles first
+
+    :param soc: Qick to be programmed
+    :type soc: QickSoc
+    :param prog: program file name
+    :type prog: string
+    :param fmt: file format
+    :type fmt: string
+    """
+    # Binary file format.
+    if fmt == "bin":
+        # Read binary file from disk.
+        with open(prog, "r") as fd:
+            progList = [int(line, 2) for line in fd]
+
+    # Asm file.
+    elif fmt == "asm":
+        # Compile program.
+        progList = parse_to_bin(prog)
+
+    soc.load_bin_program(progList)

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -2007,3 +2007,20 @@ class QickSoc(Overlay, QickConfig):
         self.start_src("internal")
         prog.load_program(self, reset=True)
         self.tproc.start()
+
+    def start_readout(self, total_count, counter_addr=1, ch_list=None, reads_per_count=1):
+        """
+        Start a streaming readout of the accumulated buffers.
+
+        This is a wrapper around DataStreamer.start_readout().
+        """
+        if ch_list is None: ch_list = [0, 1]
+        self.streamer.start_readout(total_count, counter_addr, ch_list, reads_per_count)
+
+    def poll_data(self, totaltime=0.1, timeout=None):
+        """
+        Get as much data as possible from the streamer.
+
+        This is a wrapper around DataStreamer.poll_data().
+        """
+        return self.streamer.poll_data(totaltime, timeout)

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1227,15 +1227,6 @@ class AxisTProc64x32_x8(SocIp):
             if busparser.mod2type[block] == "axis_set_reg":
                 self.trig_output = i
 
-    def start_src(self, src):
-        """
-        Sets the start source of tProc
-
-        :param src: start source "internal" or "external"
-        :type src: string
-        """
-        self.start_src_reg = {"internal": 0, "external": 1}[src]
-
     def start(self):
         """
         Start tProc from register.
@@ -1254,50 +1245,12 @@ class AxisTProc64x32_x8(SocIp):
         # we only write the high half of each program word, the low half doesn't matter
         np.copyto(self.mem.mmio.array[1::2],np.uint32(0x3F000000))
 
-    def load_bin_program(self, binprog, reset=False):
-        """
-        Write the program to the tProc program memory.
-
-        :param reset: Reset the tProc before writing the program.
-        :type reset: bool
-        """
-        if reset: self.reset()
-
-        # cast the program words to 64-bit uints
-        p = np.array(binprog, dtype=np.uint64)
-        # reshape to 32-bit uints to match the program memory, and do a fast copy
-        np.copyto(self.mem.mmio.array[:2*len(p)], np.frombuffer(p, np.uint32))
-
-    def load_program(self, prog="prog.asm", fmt="asm"):
-        """
-        Loads tProc program. If asm progam, it compiles first
-
-        :param prog: program file name
-        :type prog: string
-        :param fmt: file format
-        :type fmt: string
-        """
-        # Binary file format.
-        if fmt == "bin":
-            # Read binary file from disk.
-            with open(prog, "r") as fd:
-                progList = [int(line, 2) for line in fd]
-
-        # Asm file.
-        elif fmt == "asm":
-            # Compile program.
-            progList = parse_to_bin(prog)
-
-        self.load_bin_program(progList)
-
     def single_read(self, addr):
         """
         Reads one sample of tProc data memory using AXI access
 
         :param addr: reading address
         :type addr: int
-        :param data: value to be written
-        :type data: int
         :return: requested value
         :rtype: int
         """
@@ -2016,6 +1969,29 @@ class QickSoc(Overlay, QickConfig):
         self.iqs[ch].set_mixer_freq(f)
         self.iqs[ch].set_iq(i, q)
 
+    def load_bin_program(self, binprog, reset=False):
+        """
+        Write the program to the tProc program memory.
+
+        :param reset: Reset the tProc before writing the program.
+        :type reset: bool
+        """
+        if reset: self.tproc.reset()
+
+        # cast the program words to 64-bit uints
+        p = np.array(binprog, dtype=np.uint64)
+        # reshape to 32-bit uints to match the program memory, and do a fast copy
+        np.copyto(self.tproc.mem.mmio.array[:2*len(p)], np.frombuffer(p, np.uint32))
+
+    def start_src(self, src):
+        """
+        Sets the start source of tProc
+
+        :param src: start source "internal" or "external"
+        :type src: string
+        """
+        self.tproc.start_src_reg = {"internal": 0, "external": 1}[src]
+
     def reset_gens(self):
         """
         Reset the tProc and run a minimal tProc program that drives all signal generators with 0's.
@@ -2028,6 +2004,6 @@ class QickSoc(Overlay, QickConfig):
                 prog.pulse(ch=gen.ch,t=0)
         prog.end()
         # this should always run with internal trigger
-        self.tproc.start_src("internal")
+        self.start_src("internal")
         prog.load_program(self, reset=True)
         self.tproc.start()

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -1225,7 +1225,7 @@ class QickProgram:
         :param debug: If True, debug mode is on
         :type debug: bool
         """
-        soc.tproc.load_bin_program(self.compile(debug=debug), reset=reset)
+        soc.load_bin_program(self.compile(debug=debug), reset=reset)
 
     def get_mode_code(self, length, mode=None, outsel=None, stdysel=None, phrst=None):
         """

--- a/qick_lib/qick/streamer.py
+++ b/qick_lib/qick/streamer.py
@@ -52,9 +52,9 @@ class DataStreamer():
         self.readout_worker = self.WORKERTYPE(target=self._run_readout, daemon=True)
         self.readout_worker.start()
 
-    def start_readout(self, total_count, counter_addr=1, ch_list=None, reads_per_count=1):
+    def start_readout(self, total_count, counter_addr, ch_list, reads_per_count):
         """
-        Start a streaming readout of the average buffers.
+        Start a streaming readout of the accumulated buffers.
 
         :param total_count: Number of data points expected
         :type total_count: int
@@ -65,7 +65,6 @@ class DataStreamer():
         :param reads_per_count: Number of data points to expect per counter increment
         :type reads_per_count: int
         """
-        if ch_list is None: ch_list = [0, 1]
 
         self.total_count = total_count
         self.count = 0
@@ -112,7 +111,7 @@ class DataStreamer():
         """
         return not self.data_queue.empty()
 
-    def poll_data(self, totaltime=0.1, timeout=None):
+    def poll_data(self, totaltime, timeout):
         """
         Get as much data as possible from the data queue.
         Stop when any of the following conditions are met:


### PR DESCRIPTION
It turns out that the "autoproxy" trick for exposing class members over Pyro costs ~1 ms per call. So with the exception of get_decimated(), we no longer use autoproxied class members (the relevant methods are wrapped instead, which is ugly but worth it).

Now seeing ~4 ms per AveragerProgram execution when running without Pyro (I think the wrapped methods add some overhead), 7-10 ms when running with Pyro.