### PR TITLE
support for updates to new FW blocks; correct handling of NCO in higher nyquist zones

### DIFF
--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -126,8 +126,13 @@ class AbsSignalGen(SocIp):
         # what RFDC port does this generator drive?
         ((block, port),) = trace_net(busparser, self.fullpath, 'm_axis')
         # might need to jump through an axis_register_slice
-        while busparser.mod2type[block] == "axis_register_slice":
-            ((block, port),) = trace_net(busparser, block, 'M_AXIS')
+        while True:
+            if busparser.mod2type[block] == "axis_register_slice":
+                ((block, port),) = trace_net(busparser, block, "M_AXIS")
+            elif busparser.mod2type[block] == "axis_register_slice_nb":
+                ((block, port),) = trace_net(busparser, block, "m_axis")
+            else: # hopefully we found the data converter
+                break
         # port names are of the form 's00_axis'
         self.dac = port[1:3]
 
@@ -244,7 +249,7 @@ class AbsSignalGen(SocIp):
 class AxisSignalGen(AbsSignalGen):
     """
     AxisSignalGen class
-    Supports AxisSignalGenV4 and AxisSignalGenV5, since they have the same software interface (ignoring registers that are not used)
+    Supports AxisSignalGen V4+V5+V6, since they have the same software interface (ignoring registers that are not used)
 
     AXIS Signal Generator Registers.
     START_ADDR_REG
@@ -254,7 +259,8 @@ class AxisSignalGen(AbsSignalGen):
     * 1 : enable writes.
     """
     bindto = ['user.org:user:axis_signal_gen_v4:1.0',
-              'user.org:user:axis_signal_gen_v5:1.0']
+              'user.org:user:axis_signal_gen_v5:1.0',
+              'user.org:user:axis_signal_gen_v6:1.0']
     REGISTERS = {'start_addr_reg': 0, 'we_reg': 1, 'rndq_reg': 2}
     HAS_TPROC = True
     HAS_WAVEFORM = True
@@ -286,7 +292,6 @@ class AxisSignalGen(AbsSignalGen):
            TODO: remove this function. This functionality was removed from IP block.
         """
         self.rndq_reg = sel_
-
 
 class AxisSgInt4V1(AbsSignalGen):
     """

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -99,8 +99,11 @@ class AbsSignalGen(SocIp):
         # RF data converter
         self.rf = rf
 
-        # Sampling frequency.
-        self.fs = fs/self.FS_INTERPOLATION
+        # DAC sampling frequency.
+        self.fs_dac = fs
+
+        # DDS sampling frequency.
+        self.fs_dds = fs/self.FS_INTERPOLATION
 
     def configure_connections(self, soc, sigparser, busparser):
         self.soc = soc
@@ -229,7 +232,7 @@ class AbsSignalGen(SocIp):
             rounded_f = f
         else:
             mixercfg = {}
-            mixercfg['fs'] = self.fs*self.FS_INTERPOLATION
+            mixercfg['fs'] = self.fs_dac
             mixercfg['b_dds'] = 48
             fstep = self.soc.calc_fstep(mixercfg, self.soc['readouts'][ro_ch])
             rounded_f = round(f/fstep)*fstep
@@ -237,7 +240,7 @@ class AbsSignalGen(SocIp):
         # The frequency we calculated exactly equals (to within float precision) a valid NCO frequency.
         # So half the time, the frequency will get rounded down to the next lowest valid frequency.
         # We don't want this, so we must add a half-step to the frequency we demand.
-        rounded_f += self.fs*self.FS_INTERPOLATION/2**49
+        rounded_f += self.fs_dac/2**49
         self.rf.set_mixer_freq(self.dac, rounded_f)
 
     def get_mixer_freq(self):
@@ -412,7 +415,7 @@ class AxisSgMux4V1(AbsSignalGen):
         self.update()
 
     def get_freq(self, out=0):
-        return getattr(self, "pinc%d_reg" % (out)) * self.fs / (2**self.B_DDS)
+        return getattr(self, "pinc%d_reg" % (out)) * self.fs_dds / (2**self.B_DDS)
 
 
 class AxisConstantIQ(AbsSignalGen):
@@ -1414,6 +1417,7 @@ class AxisSwitch(SocIp):
 class RFDC(xrfdc.RFdc):
     """
     Extends the xrfdc driver.
+    Since operations on the RFdc tend to be slow (tens of ms), we cache the Nyquist zone and frequency.
     """
     bindto = ["xilinx.com:ip:usp_rf_data_converter:2.3",
               "xilinx.com:ip:usp_rf_data_converter:2.4"]
@@ -1423,9 +1427,41 @@ class RFDC(xrfdc.RFdc):
         Constructor method
         """
         super().__init__(description)
+        # Nyquist zone for each channel
         self.nqz_dict = {}
+        # Rounded NCO frequency for each channel
+        self.mixer_dict = {}
 
-    def set_mixer_freq(self, dacname, f):
+    def configure(self, soc):
+        self.daccfg = soc.dacs
+
+    def set_mixer_freq(self, dacname, f, force=False):
+        """
+        The RFdc driver does its own math to convert a frequency to a register value.
+        (see XRFdc_SetMixerSettings in xrfdc_mixer.c, and "NCO Frequency Conversion" in PG269)
+        This is what it does:
+        1. Add/subtract fs to get the frequency in the range of [-fs/2, fs/2].
+        2. If the original frequency was not in [-fs/2, fs/2] and the DAC is configured for 2nd Nyquist zone, multiply by -1.
+        3. Convert to a 48-bit register value, rounding using C integer casting (i.e. round towards 0).
+        We need to adjust the frequency so the result of this conversion equals the frequency we intended.
+        Specifically:
+        * We don't want the inversion in step 2, so we also multiply by -1.
+        * We want to get as close as possible to the demanded frequency, so we must add a half-step.
+        This is important if the demanded frequency was rounded to a valid NCO frequency for frequency-matching.
+        If we didn't add a half-step, half of the time these would get rounded down to the next lowest valid frequency.
+        """
+        fs = self.daccfg[dacname]['fs']
+        fstep = fs/2**48
+        rounded_f = round(f/fstep) * fstep
+        if not force and rounded_f == self.get_mixer_freq(dacname):
+            return
+        if (f % fs) > fs/2: # will be negative after step 1
+            f -= fstep/2
+        else: # will be positive after step 1
+            f += fstep/2
+        if abs(f) > fs/2 and self.get_nyquist(dacname)==2:
+            f *= -1
+
         tile, channel = [int(a) for a in dacname]
         # Make a copy of mixer settings.
         dac_mixer = self.dac_tiles[tile].blocks[channel].MixerSettings
@@ -1441,30 +1477,45 @@ class RFDC(xrfdc.RFdc):
         # Update settings.
         self.dac_tiles[tile].blocks[channel].MixerSettings = new_mixcfg
         self.dac_tiles[tile].blocks[channel].UpdateEvent(xrfdc.EVENT_MIXER)
+        self.mixer_dict[dacname] = rounded_f
 
     def get_mixer_freq(self, dacname):
-        tile, channel = [int(a) for a in dacname]
-        return self.dac_tiles[tile].blocks[channel].MixerSettings['Freq']
+        try:
+            return self.mixer_dict[dacname]
+        except KeyError:
+            tile, channel = [int(a) for a in dacname]
+            self.mixer_dict[dacname] = self.dac_tiles[tile].blocks[channel].MixerSettings['Freq']
+            return self.mixer_dict[dacname]
 
     def set_nyquist(self, dacname, nqz, force=False):
         """
         Sets DAC channel to operate in Nyquist zone nqz.
+        Setting the NQZ to 2 increases output power in the 2nd Nyquist zone.
         Because this takes a bit of time (10-20 ms), we do not write to the channel if the new nqz equals the previous setting.
         The "force" option overrides this behavior.
 
         :param dacname: DAC channel (2-digit string)
         :type dacname: int
-        :param nqz: Nyquist zone
+        :param nqz: Nyquist zone (1 or 2)
         :type nqz: int
         :param force: force update
         :type force: bool
         """
+        if nqz not in [1,2]:
+            raise RuntimeError("Nyquist zone must be 1 or 2")
         tile, channel = [int(a) for a in dacname]
-        if not force and (tile, channel) in self.nqz_dict:
-            if self.nqz_dict[(tile, channel)] == nqz:
-                return
-        self.nqz_dict[(tile, channel)] = nqz
+        if not force and self.get_nyquist(dacname) == nqz:
+            return
         self.dac_tiles[tile].blocks[channel].NyquistZone = nqz
+        self.nqz_dict[dacname] = nqz
+
+    def get_nyquist(self, dacname):
+        try:
+            return self.nqz_dict[dacname]
+        except KeyError:
+            tile, channel = [int(a) for a in dacname]
+            self.nqz_dict[dacname] = self.dac_tiles[tile].blocks[channel].NyquistZone
+            return self.nqz_dict[dacname]
 
 
 class QickSoc(Overlay, QickConfig):
@@ -1523,11 +1574,9 @@ class QickSoc(Overlay, QickConfig):
 
         self.config_clocks(force_init_clks)
 
-        # RF data converter (for configuring ADCs and DACs)
+        # RF data converter (for configuring ADCs and DACs, and setting NCOs)
         self.rf = self.usp_rf_data_converter_0
-
-        # Mixer for NCO ADC/DAC control.
-        self.mixer = self.usp_rf_data_converter_0
+        self.rf.configure(self)
 
         # tProcessor, 64-bit instruction, 32-bit registers, x8 channels.
         self._tproc = self.axis_tproc64x32_x8_0
@@ -1644,7 +1693,7 @@ class QickSoc(Overlay, QickConfig):
             thiscfg['switch_ch'] = gen.switch_ch
             thiscfg['tproc_ch'] = gen.tproc_ch
             thiscfg['dac'] = gen.dac
-            thiscfg['fs'] = gen.fs
+            thiscfg['fs'] = gen.fs_dds
             thiscfg['f_fabric'] = self.dacs[gen.dac]['f_fabric']
             thiscfg['samps_per_clk'] = gen.SAMPS_PER_CLK
             self['gens'].append(thiscfg)
@@ -1664,7 +1713,7 @@ class QickSoc(Overlay, QickConfig):
         for iq in self.iqs:
             thiscfg = {}
             thiscfg['dac'] = iq.dac
-            thiscfg['fs'] = iq.fs
+            thiscfg['fs'] = iq.fs_dac
             self['iqs'].append(thiscfg)
 
         self['tprocs'] = []

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -534,8 +534,9 @@ class QickProgram:
         :param maxv: Value at the peak (if None, the max value for this generator will be used)
         :type maxv: float
         """
-        if maxv is None: maxv = 2**15-2
-        samps_per_clk = self.soccfg['gens'][ch]['samps_per_clk']
+        gencfg = self.soccfg['gens'][ch]
+        if maxv is None: maxv = gencfg['maxv']*gencfg['maxv_scale']
+        samps_per_clk = gencfg['samps_per_clk']
 
         length = np.round(length) * samps_per_clk
         sigma *= samps_per_clk
@@ -563,9 +564,10 @@ class QickProgram:
         :param alpha: alpha parameter of DRAG (order-1 scale factor)
         :type alpha: float
         """
-        if maxv is None: maxv = 2**15-2
-        samps_per_clk = self.soccfg['gens'][ch]['samps_per_clk']
-        f_fabric = self.soccfg['gens'][ch]['f_fabric']
+        gencfg = self.soccfg['gens'][ch]
+        if maxv is None: maxv = gencfg['maxv']*gencfg['maxv_scale']
+        samps_per_clk = gencfg['samps_per_clk']
+        f_fabric = gencfg['f_fabric']
 
         delta /= samps_per_clk*f_fabric
 
@@ -590,8 +592,9 @@ class QickProgram:
         :param maxv: Value at the peak (if None, the max value for this generator will be used)
         :type maxv: float
         """
-        if maxv is None: maxv = 2**15-2
-        samps_per_clk = self.soccfg['gens'][ch]['samps_per_clk']
+        gencfg = self.soccfg['gens'][ch]
+        if maxv is None: maxv = gencfg['maxv']*gencfg['maxv_scale']
+        samps_per_clk = gencfg['samps_per_clk']
 
         length = np.round(length) * samps_per_clk
 
@@ -847,8 +850,10 @@ class QickProgram:
         :type length: int
         """
         p = self
-        gen_type = self.soccfg['gens'][ch]['type']
-        samps_per_clk = self.soccfg['gens'][ch]['samps_per_clk']
+        gencfg = self.soccfg['gens'][ch]
+        gen_type = gencfg['type']
+        samps_per_clk = gencfg['samps_per_clk']
+        maxv_scale = gencfg['maxv_scale']
         rp = self.ch_page(ch)
 
         last_pulse = {}
@@ -909,7 +914,7 @@ class QickProgram:
             # gain+addr for ramp-up
             p.safe_regwi(rp, r_d1, (gain << 16) | addr, f'gain = {gain} | addr = {addr}')
             # gain+addr for flat
-            p.safe_regwi(rp, r_d2, (gain//2 << 16), f'gain = {gain} | addr = {addr}')
+            p.safe_regwi(rp, r_d2, (int(gain*maxv_scale/2) << 16), f'gain = {gain} | addr = {addr}')
             # gain+addr for ramp-down
             p.safe_regwi(rp, r_d3, (gain << 16) | addr+(wfm_length+1)//2, f'gain = {gain} | addr = {addr}')
 

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -186,7 +186,7 @@ class QickConfig():
         gencfg = self['gens'][gen_ch]
         if gencfg['type'] in ['axis_sg_int4_v1', 'axis_sg_mux4_v1']:
             # because of the interpolation filter, there is no output power in the higher nyquist zones
-            if abs(f)>gencfg['fs']:
+            if abs(f)>gencfg['fs']/2:
                 raise RuntimeError("requested frequency %f is outside of the range [-fs/2, fs/2]"%(f))
         return self.freq2int(f, gencfg, rocfg) % 2**gencfg['b_dds']
 

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -183,7 +183,12 @@ class QickConfig():
             rocfg = None
         else:
             rocfg = self['readouts'][ro_ch]
-        return self.freq2int(f, self['gens'][gen_ch], rocfg)
+        gencfg = self['gens'][gen_ch]
+        if gencfg['type'] in ['axis_sg_int4_v1', 'axis_sg_mux4_v1']:
+            # because of the interpolation filter, there is no output power in the higher nyquist zones
+            if abs(f)>gencfg['fs']:
+                raise RuntimeError("requested frequency %f is outside of the range [-fs/2, fs/2]"%(f))
+        return self.freq2int(f, gencfg, rocfg) % 2**gencfg['b_dds']
 
     def freq2reg_adc(self, f, ro_ch=0, gen_ch=None):
         """

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -712,7 +712,7 @@ class QickProgram:
 
         r_e, r_d, r_c, r_b, r_a = [p.sreg(ch,x) for x in ['freq', 'phase', 'addr', 'gain', 'mode']]
 
-        if gen_type in ['axis_signal_gen_v4','axis_signal_gen_v5']:
+        if gen_type in ['axis_signal_gen_v4', 'axis_signal_gen_v5', 'axis_signal_gen_v6']:
             p.safe_regwi(rp, r_e, freq, f'freq = {freq}')
             p.safe_regwi(rp, r_d, phase, f'phase = {phase}')
             p.regwi(rp, r_b, gain, f'gain = {gain}')
@@ -789,7 +789,7 @@ class QickProgram:
 
         r_e, r_d, r_c, r_b, r_a = [p.sreg(ch,x) for x in ['freq', 'phase', 'addr', 'gain', 'mode']]
         
-        if gen_type in ['axis_signal_gen_v4','axis_signal_gen_v5']:
+        if gen_type in ['axis_signal_gen_v4', 'axis_signal_gen_v5', 'axis_signal_gen_v6']:
             p.safe_regwi(rp, r_e, freq, f'freq = {freq}')
             p.safe_regwi(rp, r_d, phase, f'phase = {phase}')
             p.regwi(rp, r_b, gain, f'gain = {gain}')
@@ -857,7 +857,7 @@ class QickProgram:
         # set the pulse duration
         last_pulse['length'] = wfm_length + length
 
-        if gen_type in ['axis_signal_gen_v4','axis_signal_gen_v5']:
+        if gen_type in ['axis_signal_gen_v4', 'axis_signal_gen_v5', 'axis_signal_gen_v6']:
             r_e, r_d, r_c, r_b, r_a = [p.sreg(ch,x) for x in ['freq', 'phase', 'addr', 'gain', 'mode']]
             r_c2, r_b2, r_a2 = [p.sreg(ch,x) for x in ['addr2', 'gain2', 'mode2']]
             p.safe_regwi(rp, r_e, freq, f'freq = {freq}')


### PR DESCRIPTION
These changes will only affect people testing the new firmware blocks that are under development.
* The v6 full-speed signal generator is now supported.
* The "int4" (interpolated, non-muxed) generator had problems where arbitrary waveforms would overshoot the max DAC value at their peaks. This is called "interpolation overshoot" and it has been resolved by scaling down (to 90%) the default amplitude for pulses using this DAC.
* The Xilinx driver for the NCO (a k a mixer) does strange things to the frequency you give it, which resulted in unexpected output frequencies when the mixer frequency was outside the 1st Nyquist zone. We are now undoing what the driver does, and it now seems OK to use NCO frequencies in the 2nd and 3rd Nyquist zones.