### PR TITLE
restructure pulse setup code

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 
 # QICK: Quantum Instrumentation Control Kit
 
-The QICK is a kit of firmware and software to use the Xilinx RFSoC as to control quantum systems.
+The QICK is a kit of firmware and software to use the Xilinx RFSoC to control quantum systems.
 
 It consists of:
-* Firmware for the ZCU111 RFSoC evaluation board.  
+* Firmware for the ZCU111 and ZCU216 RFSoC evaluation boards
 * The `qick` Python package
 * [A quick start guide](quick_start) for setting up your board and running a Jupyter notebook example
 * [Jupyter notebook examples](qick_demos) demonstrating usage
 
-Note: The firmware and software here is still very much a work in progress. This is an alpha release. We strive to be consistent with the APIs but can not guarantee backwards compatibility.
+Note: The firmware and software here is still very much a work in progress. This is an alpha release. We strive to be consistent with the APIs but cannot guarantee backwards compatibility.
 
 
 Download and Installation
@@ -25,6 +25,24 @@ Documentation
 -------------
 
 The documentation for QICK is available at: https://qick-docs.readthedocs.io/
+
+Updates
+-------
+
+Frequent updates to the QICK firmware and software are made as pull requests.
+Each pull request will be documented with a description of the notable changes, including any changes that will require you to change your code.
+We hope that this will help you decide whether or not to update your local code to the latest version.
+We strive for, but cannot guarantee, bug-free and fully functional pull requests.
+We also do not guarantee that the demo notebooks will keep pace with every pull request, though we make an effort to update the demos after major API changes.
+
+Tagged releases can be expected periodically.
+We recommend that everyone should be using at least the most recent release.
+We guarantee the following for releases:
+* The demo notebooks will be compatible with the QICK library, and will follow our current best recommendations for writing QICK programs.
+* The firmware images for all supported boards will be fully compatible with the library and the demo notebooks.
+* Release notes will summarize the pull request notes and explain both breaking API changes (what you need to change in your code) and improvements (why you should move to the new release).
+
+We recommend that you "watch" this repository on GitHub to get automatic notifications of pull requests and releases.
 
 Related Packages
 ----------------
@@ -40,6 +58,8 @@ Contribute
 You are welcome to contribute to QICK development by forking this repository and sending pull requests.
 
 All contributions are expected to be consistent with [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/).
+
+We welcome comments, bug reports, and feature requests via GitHub Issues.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ Follow the quick start guide located [here](quick_start) to set up your board, i
 Documentation
 -------------
 
-The documentation for QICK is available at: https://qick-docs.readthedocs.io/
+The API documentation for QICK is available at: https://qick-docs.readthedocs.io/
+
+The [demo notebooks](qick_demos) are intended as a tutorial.
+The first demos explain important features of the QICK system and walk you through how to write working QICK programs.
+The later demos provide examples of useful measurements you might make with the QICK.
+We recommend that new users read and understand all of the demos.
 
 Updates
 -------

--- a/pyro4/nameserver.sh
+++ b/pyro4/nameserver.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Start a Pyro4 nameserver.
+# Typically:
+# ./nameserver.sh -n 0.0.0.0 -p 8888
 export PYRO_SERIALIZERS_ACCEPTED=pickle PYRO_PICKLE_PROTOCOL_VERSION=4
 
 # pass all arguments to pyro4-ns

--- a/pyro4/server.py
+++ b/pyro4/server.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Typically (use the IP and port of your Pyro nameserver):
+# sudo -s ./server.py myqick -n 192.168.133.17 -p 8888
 import sys, getopt
 
 ns_host = None

--- a/qick_demos/06_qubit_demos.ipynb
+++ b/qick_demos/06_qubit_demos.ipynb
@@ -8,7 +8,9 @@
     "\n",
     "The measurements in this notebook were used for the QICK paper https://arxiv.org/abs/2110.00557.\n",
     "    \n",
-    "**These measurements were made a while ago, and the QICK API has changed a lot in the meantime. We try to keep this demo up to date and we make sure it runs, but we cannot guarantee that it still behaves correctly when connected to a real qubit.**"
+    "**These measurements were made a while ago, and the QICK API has changed a lot in the meantime. We try to keep this demo up to date and we make sure it runs, but we cannot guarantee that it still behaves correctly when connected to a real qubit.**\n",
+    "    \n",
+    "*It's recommended to look at the other demos to get an understanding of how the QICK programs in this demo work. You will learn things that you should know when writing your own programs.*"
    ]
   },
   {
@@ -193,6 +195,13 @@
    "source": [
     "# Load bitstream with custom overlay\n",
     "soc = QickSoc()\n",
+    "# Since we're running locally on the QICK, we don't need a separate QickConfig object.\n",
+    "# If running remotely, you could generate a QickConfig from the QickSoc:\n",
+    "#     soccfg = QickConfig(soc.get_cfg())\n",
+    "# or save the config to file, and load it later:\n",
+    "#     with open(\"qick_config.json\", \"w\") as f:\n",
+    "#         f.write(soc.dump_cfg())\n",
+    "#     soccfg = QickConfig(\"qick_config.json\")\n",
     "soccfg = soc\n",
     "\n",
     "hw_cfg={\"jpa_ch\":6,\n",

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -902,6 +902,24 @@ class QickProgram:
         """
         self.gen_mgrs[ch].set_registers(kwargs)
 
+    def setup_and_pulse(self, ch, t='auto', **kwargs):
+        """
+        Set up a pulse on this DAC channel, and immediately play it.
+        This is a wrapper around set_pulse_registers() and pulse(), and takes the arguments from both.
+        You can only run this on a single DAC channel.
+        """
+        self.set_pulse_registers(ch, **kwargs)
+        self.pulse(ch, t)
+
+    def setup_and_measure(self, adcs, pulse_ch, pins=None, adc_trig_offset=270, t='auto', wait=False, syncdelay=None, **kwargs):
+        """
+        Set up a pulse on this DAC channel, and immediately do a measurement with it.
+        This is a wrapper around set_pulse_registers() and measure(), and takes the arguments from both.
+        You can only run this on a single DAC channel.
+        """
+        self.set_pulse_registers(pulse_ch, **kwargs)
+        self.measure(adcs, pulse_ch, pins=pins, adc_trig_offset=adc_trig_offset, t=t, wait=wait, syncdelay=syncdelay)
+
     def pulse(self, ch, t='auto'):
         """
         Play the pulse currently programmed into the registers for this DAC channel.
@@ -1108,7 +1126,7 @@ class QickProgram:
         self.seti(trig_output, rp, r_out, t_start, f'ch =0 out = ${r_out} @t = {t}')
         self.seti(trig_output, rp, 0, t_end, f'ch =0 out = 0 @t = {t}')
 
-    def measure(self, adcs, pulse_ch, pins=None, adc_trig_offset=270, length=None, t='auto', wait=False, syncdelay=None):
+    def measure(self, adcs, pulse_ch, pins=None, adc_trig_offset=270, t='auto', wait=False, syncdelay=None):
         """
         Wrapper method that combines an ADC trigger, a pulse, and (optionally) the appropriate wait and a sync_all.
         You must have already run set_pulse_registers for this channel.

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -332,6 +332,215 @@ class QickConfig():
             fclk = self['fs_proc']
         return np.int64(np.round(us*fclk))
 
+class GenManager:
+    def __init__(self, prog, ch):
+        self.prog = prog
+        self.ch = ch
+        self.gencfg = prog.soccfg['gens'][ch]
+        self.samps_per_clk = self.gencfg['samps_per_clk']
+        self.rp = prog.ch_page(ch)
+        self.defaults = {}
+        self.default_regs = set()
+        self.pulses = {}
+        self.addr = 0
+        self.next_pulse = None
+        self.setup_done = False
+
+    def add_pulse(self, name, idata, qdata):
+        if qdata is None and idata is None:
+            raise RuntimeError("Error: no data argument was supplied")
+        if qdata is None:
+            qdata = np.zeros_like(idata)
+        if idata is None:
+            idata = np.zeros_like(qdata)
+        if len(idata) != len(qdata):
+            raise RuntimeError("Error: I and Q pulse lengths must be equal")
+        if (len(idata) % self.samps_per_clk) != 0:
+            raise RuntimeError("Error: pulse lengths must be an integer multiple of %d"%(self.samps_per_clk))
+        self.pulses[name] = {"idata": idata, "qdata": qdata, "addr": self.addr}
+        self.addr += len(idata)
+
+    def load_pulses(self, soc):
+        for name, pulse in self.pulses.items():
+            soc.load_pulse_data(self.ch,
+                    idata=pulse['idata'],
+                    qdata=pulse['qdata'],
+                    addr=pulse['addr'])
+
+    def set_reg(self, name, val, comment=None, defaults=False):
+        if defaults:
+            self.default_regs.add(name)
+        elif name in self.default_regs:
+            # this reg was already written, so we skip it this time
+            return
+        r = self.prog.sreg(self.ch, name)
+        if comment is None: comment = f'{name} = {val}'
+        self.prog.safe_regwi(self.rp, r, val, comment)
+
+    def set_defaults(self, kwargs):
+        if self.defaults:
+            # complain if the default parameter dict is not empty
+            raise RuntimeError("ch %d already has a set of default parameters"%(self.ch))
+        self.defaults = kwargs
+        self.write_regs(kwargs, defaults=True)
+
+    def set_registers(self, kwargs):
+        if not self.defaults.keys().isdisjoint(kwargs):
+            raise RuntimeError("these params were set for ch {0} both in default_pulse_registers and set_pulse_registers: {1}".format(ch, self.defaults.keys() & kwargs.keys()))
+        merged = {**self.defaults, **kwargs}
+        # check the final param set for validity
+        self.check_params(merged)
+        self.write_regs(merged, defaults=False)
+
+    def check_params(self, params):
+        """
+        Raise an exception if the style is not supported, or the set of defined pulse parameters is insufficient or contains parameters that cannot be applied.
+        """
+        style = params['style']
+        required = set(self.PARAMS_REQUIRED[style])
+        allowed = required | set(self.PARAMS_OPTIONAL[style])
+        defined = params.keys()
+        if required - defined:
+            raise RuntimeError("missing required pulse parameter(s)", required - defined)
+        if defined - allowed:
+            raise RuntimeError("unsupported pulse parameter(s)", defined - allowed)
+
+class FullSpeedGenManager(GenManager):
+    PARAMS_REQUIRED = {'const': ['style', 'freq', 'phase', 'gain', 'length'],
+            'arb': ['style', 'freq', 'phase', 'gain', 'waveform'],
+            'flat_top': ['style', 'freq', 'phase', 'gain', 'length', 'waveform']}
+    PARAMS_OPTIONAL = {'const': ['phrst', 'stdysel', 'mode'],
+            'arb': ['phrst', 'stdysel', 'mode', 'outsel'],
+            'flat_top': ['phrst', 'stdysel']}
+
+    def write_regs(self, params, defaults):
+        for parname in ['freq', 'phase', 'gain']:
+            if parname in params:
+                self.set_reg(parname, params[parname], defaults=defaults)
+        if 'waveform' in params:
+            pinfo = self.pulses[params['waveform']]
+            wfm_length = len(pinfo['idata']) // self.samps_per_clk
+            addr = pinfo['addr'] // self.samps_per_clk
+            self.set_reg('addr', addr, defaults=defaults)
+        if not defaults:
+            style = params['style']
+            # these mode bits could be defined, or left as None
+            phrst, stdysel, mode, outsel = [params.get(x) for x in ['phrst', 'stdysel', 'mode', 'outsel']]
+
+            self.next_pulse = {}
+            self.next_pulse['rp'] = self.rp
+            self.next_pulse['regs'] = []
+            if style=='const':
+                mc = self.prog.get_mode_code(phrst=phrst, stdysel=stdysel, mode=mode, outsel="dds", length=params['length'])
+                self.set_reg('mode', mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
+                self.next_pulse['regs'].append([self.prog.sreg(self.ch,x) for x in ['freq', 'phase', '0', 'gain', 'mode']])
+                self.next_pulse['length'] = params['length']
+            elif style=='arb':
+                mc = self.prog.get_mode_code(phrst=phrst, stdysel=stdysel, mode=mode, outsel=outsel, length=wfm_length)
+                self.set_reg('mode', mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
+                self.next_pulse['regs'].append([self.prog.sreg(self.ch,x) for x in ['freq', 'phase', 'addr', 'gain', 'mode']])
+                self.next_pulse['length'] = wfm_length
+            elif style=='flat_top':
+                # address for ramp-down
+                self.set_reg('addr2', addr+(wfm_length+1)//2)
+                # gain for flat segment
+                self.set_reg('gain2', params['gain']//2)
+                # mode for flat segment
+                mc = self.prog.get_mode_code(phrst=phrst, stdysel=stdysel, mode='oneshot', outsel='dds', length=params['length'])
+                self.set_reg('mode', mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
+                # mode for ramps
+                mc = self.prog.get_mode_code(phrst=phrst, stdysel=stdysel, mode='oneshot', outsel='product', length=wfm_length//2)
+                self.set_reg('mode2', mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
+                self.next_pulse['regs'].append([self.prog.sreg(self.ch,x) for x in ['freq', 'phase', 'addr', 'gain', 'mode2']])
+                self.next_pulse['regs'].append([self.prog.sreg(self.ch,x) for x in ['freq', 'phase', '0', 'gain2', 'mode']])
+                self.next_pulse['regs'].append([self.prog.sreg(self.ch,x) for x in ['freq', 'phase', 'addr2', 'gain', 'mode2']])
+                self.next_pulse['length'] = (wfm_length//2)*2 + params['length']
+
+
+class InterpolatedGenManager(GenManager):
+    PARAMS_REQUIRED = {'const': ['style', 'freq', 'phase', 'gain', 'length'],
+            'arb': ['style', 'freq', 'phase', 'gain', 'waveform'],
+            'flat_top': ['style', 'freq', 'phase', 'gain', 'length', 'waveform']}
+    PARAMS_OPTIONAL = {'const': ['phrst', 'stdysel', 'mode'],
+            'arb': ['phrst', 'stdysel', 'mode', 'outsel'],
+            'flat_top': ['phrst', 'stdysel']}
+
+    def write_regs(self, params, defaults):
+        addr = 0
+        if 'waveform' in params:
+            pinfo = self.pulses[params['waveform']]
+            wfm_length = len(pinfo['idata']) // self.samps_per_clk
+            addr = pinfo['addr'] // self.samps_per_clk
+        if 'phase' in params and 'freq' in params:
+            phase, freq = [params[x] for x in ['phase', 'freq']]
+            self.set_reg('freq',  (phase << 16) | freq, f'phase = {phase} | freq = {freq}', defaults=defaults)
+        if 'gain' in params and ('waveform' in params or params.get('style')=='const'):
+            gain = params['gain']
+            self.set_reg('addr',  (gain << 16) | addr, f'gain = {gain} | addr = {addr}', defaults=defaults)
+        if not defaults:
+            style = params['style']
+            # these mode bits could be defined, or left as None
+            phrst, stdysel, mode, outsel = [params.get(x) for x in ['phrst', 'stdysel', 'mode', 'outsel']]
+
+            self.next_pulse = {}
+            self.next_pulse['rp'] = self.rp
+            self.next_pulse['regs'] = []
+            if style=='const':
+                mc = self.prog.get_mode_code(phrst=phrst, stdysel=stdysel, mode=mode, outsel="dds", length=params['length'])
+                self.set_reg('mode', mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
+                self.next_pulse['regs'].append([self.prog.sreg(self.ch,x) for x in ['freq', 'addr', 'mode', '0', '0']])
+                self.next_pulse['length'] = params['length']
+            elif style=='arb':
+                mc = self.prog.get_mode_code(phrst=phrst, stdysel=stdysel, mode=mode, outsel=outsel, length=wfm_length)
+                self.set_reg('mode', mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
+                self.next_pulse['regs'].append([self.prog.sreg(self.ch,x) for x in ['freq', 'addr', 'mode', '0', '0']])
+                self.next_pulse['length'] = wfm_length
+            elif style=='flat_top':
+                maxv_scale = self.gencfg['maxv_scale']
+                gain, length = [params[x] for x in ['gain', 'length']]
+                # mode for flat segment
+                mc = self.prog.get_mode_code(phrst=phrst, stdysel=stdysel, mode="oneshot", outsel="dds", length=params['length'])
+                self.set_reg('mode', mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
+                # mode for ramps
+                mc = self.prog.get_mode_code(phrst=phrst, stdysel=stdysel, mode="oneshot", outsel="product", length=wfm_length//2)
+                self.set_reg('mode2', mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
+
+                # gain+addr for ramp-up
+                self.set_reg('addr', (gain << 16) | addr, f'gain = {gain} | addr = {addr}')
+                # gain+addr for flat
+                self.set_reg('gain', (int(gain*maxv_scale/2) << 16), f'gain = {gain} | addr = {addr}')
+                # gain+addr for ramp-down
+                self.set_reg('addr2', (gain << 16) | addr+(wfm_length+1)//2, f'gain = {gain} | addr = {addr}')
+
+                self.next_pulse['regs'].append([self.prog.sreg(self.ch,x) for x in ['freq', 'addr', 'mode2', '0', '0']])
+                self.next_pulse['regs'].append([self.prog.sreg(self.ch,x) for x in ['freq', 'gain', 'mode', '0', '0']])
+                self.next_pulse['regs'].append([self.prog.sreg(self.ch,x) for x in ['freq', 'addr2', 'mode2', '0', '0']])
+                # set the pulse duration (including the extra duration for the FIR workaround)
+                self.next_pulse['length'] = (wfm_length//2)*2 + 2*params['length']
+
+class MultiplexedGenManager(GenManager):
+    PARAMS_REQUIRED = {'const': ['style', 'mask', 'length']}
+    PARAMS_OPTIONAL = {'const': []}
+
+    def write_regs(self, params, defaults):
+        if 'length' in params:
+            self.set_reg('freq', params['length'], defaults=defaults)
+        if 'mask' in params:
+            val_mask = 0
+            mask = params['mask']
+            for maskch in mask:
+                if maskch not in range(4):
+                    raise RuntimeError("invalid mask specification")
+                val_mask |= (1 << maskch)
+            self.set_reg('phase', val_mask, f'mask = {mask}', defaults=defaults)
+        if not defaults:
+            style = params['style']
+
+            self.next_pulse = {}
+            self.next_pulse['rp'] = self.rp
+            self.next_pulse['regs'] = []
+            self.next_pulse['regs'].append([self.prog.sreg(self.ch,x) for x in ['freq', 'phase', '0', '0', '0']])
+            self.next_pulse['length'] = params['length']
 
 # configuration for an enabled readout channel
 ReadoutConfig = namedtuple('ReadoutConfig', ['freq', 'length', 'sel', 'gen_ch'])
@@ -391,6 +600,14 @@ class QickProgram:
                       'cycles2us', 'us2cycles',
                       'deg2reg', 'reg2deg']
 
+    gentypes = {'axis_signal_gen_v4': FullSpeedGenManager,
+            'axis_signal_gen_v5': FullSpeedGenManager,
+            'axis_signal_gen_v6': FullSpeedGenManager,
+            'axis_sg_int4_v1': InterpolatedGenManager,
+            'axis_sg_mux4_v1': MultiplexedGenManager}
+
+
+
     def __init__(self, soccfg):
         """
         Constructor method
@@ -400,8 +617,7 @@ class QickProgram:
         self.labels = {}
         self.dac_ts = [0]*len(soccfg['gens'])
         self.adc_ts = [0]*len(soccfg['readouts'])
-        self.channels = {ch: {"addr": 0, "pulses": {}, "default_params": {},
-                              "last_pulse": None} for ch in range(len(soccfg['gens']))}
+        self.gen_mgrs = [self.gentypes[ch['type']](self, iCh) for iCh, ch in enumerate(soccfg['gens'])]
 
         # readout channels to configure before running the program
         self.ro_chs = OrderedDict()
@@ -499,21 +715,7 @@ class QickProgram:
         :param qdata: Q data Numpy array
         :type qdata: array
         """
-        if qdata is None and idata is None:
-            raise RuntimeError("Error: no data argument was supplied")
-        if qdata is None:
-            qdata = np.zeros(len(idata))
-        if idata is None:
-            idata = np.zeros(len(qdata))
-        if len(idata) != len(qdata):
-            raise RuntimeError("Error: I and Q pulse lengths must be equal")
-        samps_per_clk = self.soccfg['gens'][ch]['samps_per_clk']
-        if (len(idata) % samps_per_clk) != 0:
-            raise RuntimeError("Error: pulse lengths must be an integer multiple of %d"%(samps_per_clk))
-
-        self.channels[ch]["pulses"][name] = {
-            "idata": idata, "qdata": qdata, "addr": self.channels[ch]['addr']}
-        self.channels[ch]["addr"] += len(idata)
+        self.gen_mgrs[ch].add_pulse(name, idata, qdata)
 
     def add_gauss(self, ch, name, sigma, length, maxv=None):
         """
@@ -604,12 +806,8 @@ class QickProgram:
         :param soc: Qick object
         :type soc: Qick object
         """
-        for ch in self.channels.keys():
-            for name, pulse in self.channels[ch]['pulses'].items():
-                idata = pulse['idata']
-                qdata = pulse['qdata']
-                soc.load_pulse_data(
-                    ch, idata=idata, qdata=qdata, addr=pulse['addr'])
+        for gen_mgr in self.gen_mgrs:
+            gen_mgr.load_pulses(soc)
 
     def ch_page(self, ch):
         """
@@ -635,17 +833,23 @@ class QickProgram:
         :return: tProc special register number
         :rtype: int
         """
+        # special case for when we want to use the zero register
+        if name=='0': return 0
         n_regs = len(self.pulse_registers)
         return 31 - (n_regs * 2) + n_regs*((ch+1)%2) + self.pulse_registers.index(name)
 
     def default_pulse_registers(self, ch, **kwargs):
         """
-        """
-        if self.channels[ch]["default_params"]:
-            # complain if the default parameter dict is not empty
-            raise RuntimeError("ch %d already has a set of default parameters"%(ch))
-        self.channels[ch]["default_params"] = kwargs
+        Set default values for pulse parameters.
+        If any registers can be written at this point, write them in order to save time later.
 
+        This is optional (you can set all parameters in set_pulse_registers).
+        You can only call this method once per channel.
+        There cannot be any overlap between the parameters defined here and the parameters you define in set_pulse_registers.
+
+        Arguments are identical to set_pulse_registers.
+        """
+        self.gen_mgrs[ch].set_defaults(kwargs)
 
     def set_pulse_registers(self, ch, **kwargs):
         #waveform=None, freq=None, phase=None, gain=None, phrst=None, stdysel=None, mode=None, outsel=None, length=None):
@@ -655,43 +859,21 @@ class QickProgram:
 
         Not all generators and pulse styles support all parameters - see the style-specific methods for more info.
 
-        Some notes on register packing for different generator and pulse types:
-        full-speed:
-        r_freq = freq
-        r_phase = phase
-        r_gain = gain
-            const:
-            r_addr = NC
-            r_mode = mode+length
-            arb:
-            r_addr = addr
-            r_mode = mode+wfm_length
-            flattop:
-            r_addr = addr
-            r_mode = flat_mode+length
-            r_mode2 = ramp_mode+ramp_length
-            r_addr2 = rampdown_addr
-            r_gain2 = flat_gain = gain/2
+        const: A constant (rectangular) pulse.
+        There is no outsel setting for this pulse style; "dds" is always used.
+        This is the only style supported by the muxed signal generator, which only takes length and mask arguments (frequency is set at program initialization).
 
-        int4:
-        r_e=r_freqphase = freq+phase
-            const:
-            r_d=r_gainaddr = gain+0
-            r_c=r_mode = mode+length
-            arb:
-            r_gainaddr = gain+addr
-            r_mode = mode+wfm_length
-            flattop:
-            r_c=r_mode = flat_mode+length
-            r_c2=r_mode2 = ramp_mode+ramp_length
-            r_d1=r_gainaddr_rampup = gain+addr
-            r_d2=r_gainaddr_flat = flat_gain+0
-            r_d3=r_gainaddr_rampup = gain+rampdown_addr
+        arb: An arbitrary-envelope pulse.
 
-        mux4:
-        r_e = length
-        r_d = mask
+        flat_top: A flattop pulse with arbitrary ramps.
+        The waveform is played in three segments: ramp up, flat, and ramp down.
+        To use these pulses one should use add_pulse to add the ramp waveform which should go from 0 to maxamp and back down to zero with the up and down having the same length, the first half will be used as the ramp up and the second half will be used as the ramp down.
 
+        If the waveform is not of even length, the middle sample will be skipped.
+        It's recommended to use an even-length waveform with flat_top.
+
+        There is no outsel setting for flat_top; the ramps always use "product" and the flat segment always uses "dds".
+        There is no mode setting; it is always "oneshot".
 
         :param ch: DAC channel (index in 'gens' list)
         :type ch: int
@@ -718,296 +900,48 @@ class QickProgram:
         :param mask: for a muxed signal generator, the list of tones to enable for this pulse
         :type mask: list
         """
-        defaults = self.channels[ch]["default_params"]
-        if not defaults.keys().isdisjoint(kwargs):
-            raise RuntimeError("these params were set both in default_pulse_registers and set_pulse_registers: {0}".format(defaults.keys() & kwargs.keys()))
-        merged = {**defaults, **kwargs}
-
-        # extract and delete the style parameter
-        style = merged.pop('style')
-        f = {'const': self.const_pulse, 'arb': self.arb_pulse,
-                     'flat_top': self.flat_top_pulse}[style]
-        return f(ch, **merged)
-
-
-    def const_pulse(self, ch, freq=None, phase=None, gain=None, phrst=None, stdysel=None, mode=None, length=None, mask=None):
-        """
-        Configure a constant (rectangular) pulse.
-
-        There is no outsel setting for this pulse style; "dds" is always used.
-
-        This is the only style supported by the muxed signal generator, which only takes length and mask arguments (frequency is set at program initialization).
-
-        :param ch: DAC channel (index in 'gens' list)
-        :type ch: int
-        :param freq: Frequency (register value)
-        :type freq: int
-        :param phase: Phase (register value)
-        :type phase: int
-        :param gain: Gain (DAC units)
-        :type gain: int
-        :param phrst: If 1, it resets the phase coherent accumulator
-        :type phrst: int
-        :param stdysel: Selects what value is output continuously by the signal generator after the generation of a pulse. If "last", it is the last calculated sample of the pulse. If "zero", it is a zero value.
-        :type stdysel: string
-        :param mode: Selects whether the output is "oneshot" or "periodic".
-        :type mode: string
-        :param length: The number of fabric clock cycles in the const portion of the pulse
-        :type length: int
-        :param mask: for a muxed signal generator, the list of tones to enable for this pulse
-        :type mask: list
-        """
-        p = self
-        gen_type = self.soccfg['gens'][ch]['type']
-        rp = self.ch_page(ch)
-
-        last_pulse = {}
-        self.channels[ch]['last_pulse'] = last_pulse
-        last_pulse['rp'] = rp
-        last_pulse['regs'] = []
-
-        # set the pulse duration
-        last_pulse['length'] = length
-
-        r_e, r_d, r_c, r_b, r_a = [p.sreg(ch,x) for x in ['freq', 'phase', 'addr', 'gain', 'mode']]
-
-        if gen_type in ['axis_signal_gen_v4', 'axis_signal_gen_v5', 'axis_signal_gen_v6']:
-            p.safe_regwi(rp, r_e, freq, f'freq = {freq}')
-            p.safe_regwi(rp, r_d, phase, f'phase = {phase}')
-            p.regwi(rp, r_b, gain, f'gain = {gain}')
-
-            mc = p.get_mode_code(phrst=phrst, stdysel=stdysel,
-                                 mode=mode, outsel="dds", length=length)
-            p.regwi(
-                rp, r_a, mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
-            last_pulse['regs'].append((r_e, r_d, 0, r_b, r_a))
-        elif gen_type == 'axis_sg_int4_v1':
-            p.safe_regwi(rp, r_e, (phase << 16) | freq, f'phase = {phase} | freq = {freq}')
-            p.safe_regwi(rp, r_d, (gain << 16), f'gain = {gain}')
-            mc = p.get_mode_code(phrst=phrst, stdysel=stdysel,
-                                 mode=mode, outsel="dds", length=length)
-            p.regwi(
-                rp, r_c, mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
-            last_pulse['regs'].append((r_e, r_d, r_c, 0, 0))
-        elif gen_type == 'axis_sg_mux4_v1':
-            if mask is None:
-                raise RuntimeError("mask must be specified for mux generator")
-            if any([x is not None for x in [stdysel, phrst, mode, freq, phase, gain]]):
-                raise RuntimeError(gen_type, "does not support specified options")
-            p.safe_regwi(rp, r_e, length, f'length = {length}')
-            val_mask = 0
-            for maskch in mask:
-                if maskch not in range(4):
-                    raise RuntimeError("invalid mask specification")
-                val_mask |= (1 << maskch)
-            p.regwi(rp, r_d, val_mask, f'mask = {mask}')
-            last_pulse['regs'].append((r_e, r_d, 0, 0, 0))
-        else:
-            raise RuntimeError("this is not a tProc-controlled signal generator:", gen_type)
-
-    def arb_pulse(self, ch, waveform=None, freq=None, phase=None, gain=None, phrst=None, stdysel=None, mode=None, outsel=None):
-        """
-        Configure an arbitrary pulse, can autoschedule this based on previous pulses.
-
-        :param ch: DAC channel (index in 'gens' list)
-        :type ch: int
-        :param waveform: Name of the envelope waveform loaded with add_pulse()
-        :type waveform: string
-        :param freq: Frequency (register value)
-        :type freq: int
-        :param phase: Phase (register value)
-        :type phase: int
-        :param gain: Gain (DAC units)
-        :type gain: int
-        :param phrst: If 1, it resets the phase coherent accumulator
-        :type phrst: int
-        :param stdysel: Selects what value is output continuously by the signal generator after the generation of a pulse. If "last", it is the last calculated sample of the pulse. If "zero", it is a zero value.
-        :type stdysel: string
-        :param mode: Selects whether the output is "oneshot" or "periodic".
-        :type mode: string
-        :param outsel: Selects the output source. The output is complex. Tables define envelopes for I and Q. If "product", the output is the product of table and DDS. If "dds", the output is the DDS only. If "input", the output is from the table for the real part, and zeros for the imaginary part. If "zero", the output is always zero.
-        :type outsel: string
-        """
-        p = self
-        gen_type = self.soccfg['gens'][ch]['type']
-        samps_per_clk = self.soccfg['gens'][ch]['samps_per_clk']
-        rp = self.ch_page(ch)
-
-        last_pulse = {}
-        self.channels[ch]['last_pulse'] = last_pulse
-        last_pulse['rp'] = rp
-        last_pulse['regs'] = []
-
-        pinfo = self.channels[ch]['pulses'][waveform]
-
-        addr = pinfo["addr"]//samps_per_clk
-        wfm_length = len(pinfo["idata"])//samps_per_clk
-        # set the pulse duration
-        last_pulse['length'] = wfm_length
-
-        r_e, r_d, r_c, r_b, r_a = [p.sreg(ch,x) for x in ['freq', 'phase', 'addr', 'gain', 'mode']]
-        
-        if gen_type in ['axis_signal_gen_v4', 'axis_signal_gen_v5', 'axis_signal_gen_v6']:
-            p.safe_regwi(rp, r_e, freq, f'freq = {freq}')
-            p.safe_regwi(rp, r_d, phase, f'phase = {phase}')
-            p.regwi(rp, r_b, gain, f'gain = {gain}')
-
-            p.regwi(rp, r_c, addr, f'addr = {addr}')
-            mc = p.get_mode_code(phrst=phrst, stdysel=stdysel,
-                                 mode=mode, outsel=outsel, length=wfm_length)
-            p.regwi(
-                rp, r_a, mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
-            last_pulse['regs'].append((r_e, r_d, r_c, r_b, r_a))
-        elif gen_type == 'axis_sg_int4_v1':
-            p.safe_regwi(rp, r_e, (phase << 16) | freq, f'phase = {phase} | freq = {freq}')
-            p.safe_regwi(rp, r_d, (gain << 16) | addr, f'gain = {gain} | addr = {addr}')
-            mc = p.get_mode_code(phrst=phrst, stdysel=stdysel,
-                                 mode=mode, outsel=outsel, length=wfm_length)
-            p.regwi(
-                rp, r_c, mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
-            last_pulse['regs'].append((r_e, r_d, r_c, 0, 0))
-        else:
-            raise RuntimeError("this generator does not support arb pulse:", gen_type)
-
-    def flat_top_pulse(self, ch, waveform=None, freq=None, phase=None, gain=None, phrst=None, stdysel=None, length=None):
-        """
-        Program a flattop pulse with arbitrary ramps.
-        The waveform is played in three segments: ramp up, flat, and ramp down.
-        To use these pulses one should use add_pulse to add the ramp waveform which should go from 0 to maxamp and back down to zero with the up and down having the same length, the first half will be used as the ramp up and the second half will be used as the ramp down.
-
-        If the waveform is not of even length, the middle sample will be skipped.
-        It's recommended to use an even-length waveform.
-
-        There is no outsel setting for this pulse style; the ramps always use "product" and the flat segment always uses "dds".
-        There is no mode setting for this pulse style; it is always "oneshot".
-
-        :param ch: DAC channel (index in 'gens' list)
-        :type ch: int
-        :param waveform: Name of the envelope waveform loaded with add_pulse()
-        :type waveform: string
-        :param freq: Frequency (register value)
-        :type freq: int
-        :param phase: Phase (register value)
-        :type phase: int
-        :param gain: Gain (DAC units)
-        :type gain: int
-        :param phrst: If 1, it resets the phase coherent accumulator
-        :type phrst: int
-        :param stdysel: Selects what value is output continuously by the signal generator after the generation of a pulse. If "last", it is the last calculated sample of the pulse. If "zero", it is a zero value.
-        :type stdysel: string
-        :param length: The number of fabric clock cycles in the const portion of the pulse
-        :type length: int
-        """
-        p = self
-        gencfg = self.soccfg['gens'][ch]
-        gen_type = gencfg['type']
-        samps_per_clk = gencfg['samps_per_clk']
-        maxv_scale = gencfg['maxv_scale']
-        rp = self.ch_page(ch)
-
-        last_pulse = {}
-        self.channels[ch]['last_pulse'] = last_pulse
-        last_pulse['rp'] = rp
-        last_pulse['regs'] = []
-
-        pinfo = self.channels[ch]['pulses'][waveform]
-        addr = pinfo["addr"]//samps_per_clk
-        wfm_length = len(pinfo["idata"])//samps_per_clk
-
-        if gen_type in ['axis_signal_gen_v4', 'axis_signal_gen_v5', 'axis_signal_gen_v6']:
-            # set the pulse duration
-            last_pulse['length'] = wfm_length + length
-            r_e, r_d, r_c, r_b, r_a = [p.sreg(ch,x) for x in ['freq', 'phase', 'addr', 'gain', 'mode']]
-            r_c2, r_b2, r_a2 = [p.sreg(ch,x) for x in ['addr2', 'gain2', 'mode2']]
-            p.safe_regwi(rp, r_e, freq, f'freq = {freq}')
-            p.safe_regwi(rp, r_d, phase, f'phase = {phase}')
-            # gain for ramps
-            p.regwi(rp, r_b, gain, f'gain = {gain}')
-
-            # address for ramp-up
-            p.regwi(rp, r_c, addr, f'addr = {addr}')
-            # address for ramp-down
-            p.regwi(rp, r_c2, addr+(wfm_length+1)//2, f'addr = {addr}')
-            # gain for flat segment
-            p.regwi(rp, r_b2, gain//2, f'gain = {gain}')
-            # mode for flat segment
-            mc = p.get_mode_code(phrst=phrst, stdysel=stdysel,
-                                 mode="oneshot", outsel="dds", length=length)
-            p.regwi(rp, r_a, mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
-            # mode for ramps
-            mc = p.get_mode_code(phrst=phrst, stdysel=stdysel,
-                                 mode="oneshot", outsel="product", length=wfm_length//2)
-            p.regwi(rp, r_a2, mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
-
-            last_pulse['regs'].append((r_e, r_d, r_c, r_b, r_a2))
-            last_pulse['regs'].append((r_e, r_d, 0, r_b2, r_a))
-            last_pulse['regs'].append((r_e, r_d, r_c2, r_b, r_a2))
-        elif gen_type == 'axis_sg_int4_v1':
-            # set the pulse duration (including the extra duration for the FIR workaround)
-            last_pulse['length'] = wfm_length + 2*length
-            # phase+freq
-            r_e = p.sreg(ch,'freq')
-            r_c, r_c2 = [p.sreg(ch,x) for x in ['mode', 'mode2']]
-            # gain+addr
-            r_d1, r_d2, r_d3 = [p.sreg(ch,x) for x in ['addr', 'gain', 'addr2']]
-
-            p.safe_regwi(rp, r_e, (phase << 16) | freq, f'phase = {phase} | freq = {freq}')
-
-            # mode for flat segment
-            mc = p.get_mode_code(phrst=phrst, stdysel=stdysel,
-                                 mode="oneshot", outsel="dds", length=length)
-            p.regwi(rp, r_c, mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
-            # mode for ramps
-            mc = p.get_mode_code(phrst=phrst, stdysel=stdysel,
-                                 mode="oneshot", outsel="product", length=wfm_length//2)
-            p.regwi(rp, r_c2, mc, f'stdysel | mode | outsel = 0b{mc//2**16:>05b} | length = {mc % 2**16} ')
-
-            # gain+addr for ramp-up
-            p.safe_regwi(rp, r_d1, (gain << 16) | addr, f'gain = {gain} | addr = {addr}')
-            # gain+addr for flat
-            p.safe_regwi(rp, r_d2, (int(gain*maxv_scale/2) << 16), f'gain = {gain} | addr = {addr}')
-            # gain+addr for ramp-down
-            p.safe_regwi(rp, r_d3, (gain << 16) | addr+(wfm_length+1)//2, f'gain = {gain} | addr = {addr}')
-
-            last_pulse['regs'].append((r_e, r_d1, r_c2, 0, 0))
-            last_pulse['regs'].append((r_e, r_d2, r_c, 0, 0))
-            last_pulse['regs'].append((r_e, r_d3, r_c2, 0, 0))
-            # workaround for FIR bug: we play a zero-gain DDS pulse (length equal to the flat segment) after the ramp-down, which brings the FIR to zero
-            last_pulse['regs'].append((0, 0, r_c, 0, 0))
-        else:
-            raise RuntimeError("this generator does not support flat_top pulse:", gen_type)
+        self.gen_mgrs[ch].set_registers(kwargs)
 
     def pulse(self, ch, t='auto'):
         """
         Play the pulse currently programmed into the registers for this DAC channel.
+        You must have already run set_pulse_registers for this channel.
 
         :param ch: DAC channel (index in 'gens' list)
-        :type ch: int
+        :type ch: int or list
         :param t: The number of clock ticks at which point the pulse starts (None to use the time register as is, 'auto' to start whenever the last pulse ends)
         :type t: int
         """
-        rp = self.ch_page(ch)
-        tproc_ch = self.soccfg['gens'][ch]['tproc_ch']
-        last_pulse = self.channels[ch]['last_pulse']
+        # try to convert pulse_ch to int; if that fails, assume it's list of ints
+        try:
+            ch_list = [int(ch)]
+        except TypeError:
+            ch_list = ch
+        for ch in ch_list:
+            rp = self.ch_page(ch)
+            tproc_ch = self.soccfg['gens'][ch]['tproc_ch']
+            next_pulse = self.gen_mgrs[ch].next_pulse
+            if next_pulse is None:
+                raise RuntimeError("no pulse has been set up for channel %d"%(ch))
 
-        r_t = self.sreg(ch, 't')
-        
-        if t is not None:
-            if t == 'auto':
-                t = int(self.dac_ts[ch])
-            elif t < self.dac_ts[ch]:
-                print("warning: pulse time %d appears to conflict with previous pulse ending at %f?"%(t, self.dac_ts[ch]))
-            # convert from generator clock to tProc clock
-            pulse_length = last_pulse['length']
-            pulse_length *= self.soccfg['fs_proc']/self.soccfg['gens'][ch]['f_fabric']
-            self.dac_ts[ch] = t + pulse_length
-            self.safe_regwi(rp, r_t, t, f't = {t}')
+            r_t = self.sreg(ch, 't')
 
-        # Play each pulse segment.
-        # We specify the same time for all segments and rely on the signal generator to concatenate them without gaps.
-        # We could specify the "correct" times, but it's difficult to get right when the tProc and generator clocks are different.
-        for regs in last_pulse['regs']:
-            self.set(tproc_ch, rp, *regs, r_t, f"ch = {ch}, pulse @t = ${r_t}")
+            if t is not None:
+                if t == 'auto':
+                    t = int(self.dac_ts[ch])
+                elif t < self.dac_ts[ch]:
+                    print("warning: pulse time %d appears to conflict with previous pulse ending at %f?"%(t, self.dac_ts[ch]))
+                # convert from generator clock to tProc clock
+                pulse_length = next_pulse['length']
+                pulse_length *= self.soccfg['fs_proc']/self.soccfg['gens'][ch]['f_fabric']
+                self.dac_ts[ch] = t + pulse_length
+                self.safe_regwi(rp, r_t, t, f't = {t}')
+
+            # Play each pulse segment.
+            # We specify the same time for all segments and rely on the signal generator to concatenate them without gaps.
+            # We could specify the "correct" times, but it's difficult to get right when the tProc and generator clocks are different.
+            for regs in next_pulse['regs']:
+                self.set(tproc_ch, rp, *regs, r_t, f"ch = {ch}, pulse @t = ${r_t}")
 
     def safe_regwi(self, rp, reg, imm, comment=None):
         """
@@ -1177,13 +1111,14 @@ class QickProgram:
     def measure(self, adcs, pulse_ch, pins=None, adc_trig_offset=270, length=None, t='auto', wait=False, syncdelay=None):
         """
         Wrapper method that combines an ADC trigger, a pulse, and (optionally) the appropriate wait and a sync_all.
+        You must have already run set_pulse_registers for this channel.
 
         If you use wait=True, it's recommended to also specify a nonzero syncdelay.
 
         :param adcs: ADC channels
         :type adcs: list
         :param pulse_ch: DAC channel
-        :type pulse_ch: int
+        :type pulse_ch: int or list
         :param pins: List of marker pins to pulse.
         :type pins: list
         :param adc_trig_offset: Offset time at which the ADC is triggered (in clock ticks)

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -643,8 +643,9 @@ class QickProgram:
         """
         if self.channels[ch]["default_params"]:
             # complain if the default parameter dict is not empty
-            raise RuntimeException("ch %d already has a set of default parameters"%(ch))
+            raise RuntimeError("ch %d already has a set of default parameters"%(ch))
         self.channels[ch]["default_params"] = kwargs
+
 
     def set_pulse_registers(self, ch, **kwargs):
         #waveform=None, freq=None, phase=None, gain=None, phrst=None, stdysel=None, mode=None, outsel=None, length=None):
@@ -719,7 +720,7 @@ class QickProgram:
         """
         defaults = self.channels[ch]["default_params"]
         if not defaults.keys().isdisjoint(kwargs):
-            raise RuntimeException("these params were set both in default_pulse_registers and set_pulse_registers: {0}".format(defaults.keys() & kwargs.keys()))
+            raise RuntimeError("these params were set both in default_pulse_registers and set_pulse_registers: {0}".format(defaults.keys() & kwargs.keys()))
         merged = {**defaults, **kwargs}
 
         # extract and delete the style parameter


### PR DESCRIPTION
It's now possible to write a partial ("default") set of pulse parameters to a signal generator using `default_pulse_registers()`.
If you are playing multiple pulses on this generator, and the pulses share some params (e.g. freq, phase) but not others, the later `set_pulse_registers()` calls are simplified (and consume less tProc time).

There are also some convenience tweaks to the `pulse()` and `measure()` methods - both now accept lists of DAC channels to pulse simultaneously, and both now have `setup_and_` equivalents that wrap `set_pulse_registers()` (but only accept single DAC channels).

These changes should be fully backwards-compatible.