### PR TITLE
misc. version support tweaks

### DIFF
--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1968,13 +1968,22 @@ class QickSoc(Overlay, QickConfig):
         if self['board'] == 'ZCU111':
             print("resetting clocks:", self['refclk_freq'])
 
-            # load the clock chip configurations from file, so we can then modify them
-            xrfclk.xrfclk._find_devices()
-            xrfclk.xrfclk._read_tics_output()
-            if self.ENABLE_LO_OUTPUT:
-                # change the register for the LMK04208 chip's 5th output, which goes to J108
-                # we need this for driving the RF board
-                xrfclk.xrfclk._Config['lmk04208'][122.88][6] = 0x00140325
+            if hasattr(xrfclk, "xrfclk"):
+                # load the default clock chip configurations from file, so we can then modify them
+                xrfclk.xrfclk._find_devices()
+                xrfclk.xrfclk._read_tics_output()
+                if self.ENABLE_LO_OUTPUT:
+                    # change the register for the LMK04208 chip's 5th output, which goes to J108
+                    # we need this for driving the RF board
+                    xrfclk.xrfclk._Config['lmk04208'][122.88][6] = 0x00140325
+            else:
+                if self.ENABLE_LO_OUTPUT:
+                    # change the register for the LMK04208 chip's 5th output, which goes to J108
+                    # we need this for driving the RF board
+                    xrfclk._lmk04208Config[122.88][6] = 0x00140325
+                else:
+                    # restore the default clock config
+                    xrfclk._lmk04208Config[122.88][6] = 0x80141E05
 
             xrfclk.set_all_ref_clks(self['refclk_freq'])
         elif self['board'] == 'ZCU216':

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup(
     # but qick_asm.py, averager_program.py, and the notebooks should still work.
     install_requires=[
         "numpy",
-        "pynq;platform_machine=='aarch64' or platform_machine=='armv7l'",
+        "pynq>=2.6;platform_machine=='aarch64' or platform_machine=='armv7l'",
         "tqdm"],  # Optional
 
     # List additional groups of dependencies here (e.g. development
@@ -210,8 +210,9 @@ setup(
     # maintainers, and where to support the project financially. The key is
     # what's used to render the link text on PyPI.
     project_urls={  # Optional
+        'Source': 'https://github.com/openquantumhardware/qick',
         'Documentation': 'https://qick-docs.readthedocs.io/en/latest/',
-        'Documentation Repo': 'https://github.com/openquantumhardware/qick-docs',
+        'Tracker': 'https://github.com/openquantumhardware/qick/issues',
     },
 )
 


### PR DESCRIPTION
* make the RF board work on pynq 2.6 as well as pynq 2.7
* setup.py now requires pynq>.2.6 (this is a trivial requirement, nobody is running anything older, but it's good to make it explicit)