### PR TITLE
Add compatibility with RPyC (https://rpyc.readthedocs.io/).

### DIFF
--- a/qick_lib/qick/averager_program.py
+++ b/qick_lib/qick/averager_program.py
@@ -7,7 +7,11 @@ except:
     from tqdm import tqdm_notebook as tqdm
 import numpy as np
 from .qick_asm import QickProgram
-
+try:
+    from rpyc.utils.classic import obtain
+except:
+    def obtain(i):
+        return i
 
 class AveragerProgram(QickProgram):
     """
@@ -318,8 +322,8 @@ class AveragerProgram(QickProgram):
                 count = tproc.single_read(addr=1)
 
             for ii, (ch, ro) in enumerate(self.ro_chs.items()):
-                d_buf[ii] += soc.get_decimated(ch=ch,
-                                               address=0, length=ro.length*reps*readouts_per_experiment)
+                d_buf[ii] += obtain(soc.get_decimated(ch=ch,
+                                    address=0, length=ro.length*reps*readouts_per_experiment))
 
         # average the decimated data
         if reps == 1 and readouts_per_experiment == 1:

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -15,6 +15,11 @@ import queue
 from .parser import parse_to_bin
 from .streamer import DataStreamer
 from .qick_asm import QickConfig, QickProgram
+try:
+    from rpyc.utils.classic import obtain
+except ModuleNotFoundError:
+    def obtain(i):
+        return i
 from .helpers import trace_net, get_fclk, BusParser
 from . import bitfile_path
 
@@ -2232,7 +2237,7 @@ class QickSoc(Overlay, QickConfig):
         if reset: self.tproc.reset()
 
         # cast the program words to 64-bit uints
-        self.binprog = np.array(binprog, dtype=np.uint64)
+        self.binprog = np.array(obtain(binprog), dtype=np.uint64)
         # reshape to 32 bits to match the program memory
         self.binprog = np.frombuffer(self.binprog, np.uint32)
 


### PR DESCRIPTION
Tested generation of pulse sequences and ADC readout with acquired_decimated() using AveragerProgram. acquire() and other readout functions may still not work.