### PR TITLE
updates for V2 RF board support

### DIFF
--- a/qick_lib/qick/ipq_pynq_utils/LICENSE
+++ b/qick_lib/qick/ipq_pynq_utils/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, Karlsruhe Institute of Technology - Institute of Photonics and Quantum Electronics (IPQ)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/qick_lib/qick/ipq_pynq_utils/README.md
+++ b/qick_lib/qick/ipq_pynq_utils/README.md
@@ -1,0 +1,6 @@
+# IPQ PYNQ Utilities
+This code is a subset of the PYNQ utilities developed by KIT-IPQ, with modifications to suit use in QICK.
+While the original project is used mainly to configure the CLK104 daughterboard on the ZCU208/216, we are using the same code to configure the LMX2594 oscillator on the V2 RF board.
+
+The original project can be found at https://github.com/kit-ipq/ipq-pynq-utils.
+The license (which includes attribution) is preserved without modification in this directory.

--- a/qick_lib/qick/ipq_pynq_utils/clock_models.py
+++ b/qick_lib/qick/ipq_pynq_utils/clock_models.py
@@ -390,12 +390,6 @@ class LMX2594(RegisterDevice):
         self.MASH_RESET_N.set(self.MASH_RESET_N.RESET)
         self.PLL_NUM.value = 0
         self.PLL_DEN.value = 0
-        mult = 1
-        osc_x = 2 if osc_2x else 1
-        if osc_2x:
-            osc_x = 2
-        else:
-            osc_x = 1
 
         self.OUTA_PWR.value = pwr
         self.OUTA_PD.set(self.OUTA_PD.NORMAL_OPERATION)
@@ -409,6 +403,8 @@ class LMX2594(RegisterDevice):
         chdivs = []
         f_vco_min = 7500
 
+        mult = 1
+        osc_x = 2 if osc_2x else 1
         for i,(div,f_vco_max,f_out_min,f_out_max) in enumerate(CHDIV_TABLE):
             if not (f_out_min <= f_target <= f_out_max):
                 continue

--- a/qick_lib/qick/ipq_pynq_utils/clock_models.py
+++ b/qick_lib/qick/ipq_pynq_utils/clock_models.py
@@ -1,0 +1,996 @@
+"""
+Implements different clock / PLL models for easy manipulation without vendor software.
+"""
+
+import json
+import re
+import numpy as np
+#from . import utils
+import os
+import fractions
+
+class EnumVal:
+    def __init__(self, name, value, description):
+        self.name = name
+        self.value = value
+        self.description = description
+        self.__doc__ = self.description
+
+    @property
+    def __pydoc__(self):
+        return self.description
+
+    def get(self):
+        return self.value
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return self.name
+
+class ConstantField:
+    def __init__(self, field):
+        self.end = field["end"]
+        self.start = field["start"]
+        self.value = field["value"]
+        self.name = "CONST"
+        self.description = ""
+
+        self.width = self.end - self.start + 1
+        self.mask = ((1 << self.width) - 1) << self.start
+
+    def get(self):
+        return self.value
+
+    def get_raw(self):
+        return self.mask & (self.value << self.start)
+
+    def parse(self, obj):
+        pass
+
+    @property
+    def value_description(self):
+        return ""
+
+    def __str__(self):
+        return str(self.value)
+
+    def __repr__(self):
+        return str(self.value)
+
+class Field:
+    def __init__(self, field):
+        self.end = field["end"]
+        self.start = field["start"]
+        self.width = self.end - self.start + 1
+        self.mask = ((1 << self.width) - 1) << self.start
+
+        self.name = field["name"]
+        self.description = field["description"]
+        self.__doc__ = self.description
+        self.default = field["default"] if "default" in field else 0
+        self.value = self.default
+
+        self.enum_map = {}
+
+        valid = field["valid"]
+        self.valid_type = valid["type"]
+
+        if self.valid_type == "int":
+            pass # ??
+        elif self.valid_type == "constant":
+            self.default = valid["value"]
+            self.value = valid["value"]
+        elif self.valid_type == "enum":
+            for value in valid["values"]:
+                enum_val = EnumVal(**value)
+                assert getattr(self, value["name"], None) is None, f"Duplicate enum value in field {self.name}: {value['name']}"
+                setattr(self, value["name"], enum_val)
+                self.enum_map[enum_val.value] = enum_val
+        else:
+            raise RuntimeError("Unknown valid type: " + self.valid_type)
+
+    def get(self):
+        if self.valid_type == "enum":
+            if self.value in self.enum_map:
+                return self.enum_map[self.value]
+            else:
+                return "BAD ENUM VALUE"
+        return self.value
+
+    def set(self, value):
+        if self.value_type == "enum":
+            if not isinstance(value, EnumVal):
+                raise RuntimeError("Expected enum value!")
+            else:
+                self.value = value.value
+        else:
+            self.value = value
+
+    def get_raw(self):
+        return self.mask & (self.value << self.start)
+
+    def parse(self, data):
+        self.value = (data & self.mask) >> self.start
+
+    def set(self, val):
+        if isinstance(val, int):
+            self.value = val
+        elif isinstance(val, EnumVal):
+            self.value = val.value
+        else:
+            raise RuntimeError("Unsupported type!")
+
+    def reset(self):
+        self.value = self.default
+
+    @property
+    def value_description(self):
+        if self.valid_type == "enum":
+            if self.value in self.enum_map:
+                return self.enum_map[self.value].description
+            else:
+                return "BAD ENUM VALUE"
+        return ""
+
+    def __str__(self):
+        return str(self.__dict__)
+
+    def __repr__(self):
+        return str(self.__dict__)
+
+class Register:
+    def __init__(self, obj, dw=8):
+        self.addr = obj["addr"]
+        self.fields = []
+        self.dw = dw 
+
+        for field in obj["fields"]:
+            fieldtype = field["fieldtype"]
+            if fieldtype == "constant":
+                self.fields.append(ConstantField(field))
+            elif fieldtype == "normal":
+                self.fields.append(Field(field))
+            else:
+                raise RuntimeError("Unsupported field type!")
+
+    def reset(self):
+        for field in self.fields:
+            field.reset()
+
+    def parse(self, val):
+        for field in self.fields:
+            field.parse(val)
+
+    def __str__(self):
+        return str({"addr": self.addr, "fields": self.fields})
+
+    def __repr__(self):
+        return str({"addr": self.addr, "fields": self.fields})
+
+    def get_raw(self):
+        ret = self.addr << self.dw
+
+        for field in self.fields:
+            ret |= field.get_raw()
+
+        return ret
+
+class MultiRegister:
+    def __init__(self, parent, name, fields):
+        self.parent = parent
+        self.fields = fields
+        self.name = name
+
+    @property
+    def value(self):
+        return self.parent.get_long_register(*self.fields)
+
+    @value.setter
+    def value(self, v):
+        self.parent.set_long_register(v, *self.fields)
+
+class RegisterDevice:
+    def __init__(self, aw, dw, definition):
+        # Address width and data width
+        self.aw = aw
+        self.dw = dw
+        self.registers_by_addr = {}
+        self.regname_pattern = re.compile(r"[A-Za-z0-9_]+\[(\d+):(\d+)\]")
+
+        defpath = os.path.join(os.path.dirname(__file__), definition)
+        with open(defpath) as f:
+            regmap = json.load(f)
+
+        multi_regs = {}
+
+        for register in regmap:
+            addr = register["addr"]
+            reg = Register(register, dw=dw)
+            self.registers_by_addr[addr] = reg
+
+            for field in reg.fields:
+                if isinstance(field, Field) and field.valid_type != "constant":
+                    sanitized_name = field.name.replace("[", "_").replace("]", "").replace(":", "_")
+                    if field.name.endswith("]"): # Multi-field
+                        name = field.name[:field.name.index("[")]
+                        multi_regs[name] = multi_regs.get(name, []) + [field]
+                    setattr(self, sanitized_name, field)
+
+        for k,v in multi_regs.items():
+            setattr(self, k, MultiRegister(self, k, v))
+
+    def init_from_file(self, file):
+        if hasattr(file, "read"):
+            lines = file.read().strip().split("\n")
+        else:
+            with open(file, "r") as f:
+                lines = f.read().strip().split("\n")
+
+        for line in lines:
+            a,b = line.split("\t")
+            rawdata = int(b, 16)
+
+            addr_mask = (1 << self.aw) - 1
+            addr = addr_mask & (rawdata >> self.dw)
+            data_mask = (1 << self.dw) - 1
+            data = rawdata & data_mask
+
+            if not addr in self.registers_by_addr:
+                print(f"Unhandled register: {hex(addr)}, skipping ...")
+                print()
+                continue
+
+            self.registers_by_addr[addr].parse(data)
+
+        self.update()
+
+    def get_long_register(self, *args):
+        ret = 0
+        for field in args:
+            match = self.regname_pattern.match(field.name)
+            if match is None:
+                raise RuntimeError("Cannot read non-long field: " + field.name)
+
+            end = int(match.group(1))
+            start = int(match.group(2))
+            width = end-start+1
+            mask = ((1 << width)-1)
+
+            val = (field.value & mask)
+            ret |= val << start
+
+        return ret
+
+    def set_long_register(self, value, *args):
+        for field in args:
+            match = self.regname_pattern.match(field.name)
+            if match is None:
+                raise RuntimeError("Cannot read non-long field: " + field.name)
+
+            end = int(match.group(1))
+            start = int(match.group(2))
+            width = end-start+1
+            mask = ((1 << width)-1)
+            value_mask = mask << start
+
+            field.value = (value & value_mask) >> start
+
+    def get_register_dump(self, with_addr=False):
+        ret = []
+        for addr in self.register_addresses:
+            if not with_addr:
+                ret.append(self.registers_by_addr[addr].get_raw())
+            else:
+                ret.append((addr, self.registers_by_addr[addr].get_raw()))
+
+        return ret
+
+    def print(self):
+        for addr in self.register_addresses:
+            register = self.registers_by_addr[addr]
+
+            for field in register.fields:
+                val = field.get()
+                if field.name == "CONST":
+                    continue
+
+                print(f"    {field.name}")
+                print(f"        Description: {field.description}")
+                print(f"        Value:       {val}")
+                if field.valid_type == "enum":
+                    print(f"        ValDesc:     {field.value_description}")
+                print()
+
+LMX2594_VCOs = [
+        (1,  7500,  8600, 164, 12, 299, 240),
+        (2,  8600,  9800, 165, 16, 356, 247),
+        (3,  9800, 10800, 158, 19, 324, 224),
+        (4, 10800, 12000, 140,  0, 383, 244),
+        (5, 12000, 12900, 183, 36, 205, 146),
+        (6, 12900, 13900, 155,  6, 242, 163),
+        (7, 13900, 15000, 175, 19, 323, 244)
+    ]
+
+CAL_NO_ASSIST = 0
+CAL_PARTIAL_ASSIST = 1
+CAL_CLOSE_FREQUENCY_ASSIST = 2
+CAL_FULL_ASSIST = 3
+
+CHDIV_TABLE = [
+        (2, 15000, 3750, 7500),
+        (4, 15000, 1875, 3750),
+        (6, 15000, 1250, 2500),
+        (8, 11500, 937.5, 1437.5),
+        (12, 11500, 625, 958.333),
+        (16, 11500, 468.75, 718.75),
+        (24, 11500, 312.5, 479.167),
+        (32, 11500, 234.375, 359.375),
+        (48, 11500, 156.25, 239.583),
+        (64, 11500, 117.1875, 179.6875),
+        (72, 11500, 104.167, 159.722),
+        (96, 11500, 78.125, 119.792),
+        (128, 11500, 58.594, 89.844),
+        (192, 11500, 39.0625, 59.896),
+        (256, 11500, 29.297, 44.922),
+        (384, 11500, 19.531, 29.948),
+        (512, 11500, 14.648, 22.461),
+        (768, 11500, 9.766, 14.974),
+        (1, 15000, 10, 15000)
+        ]
+
+class LMX2594(RegisterDevice):
+
+    def __init__(self, f_osc):
+        RegisterDevice.__init__(self, 8, 16, "lmx2594_regmap.json")
+
+        self.f_osc = f_osc
+
+        # Note that this isn't the complete range, but skips the readback registers
+        self.register_addresses = list(range(109, -1, -1))
+
+    def set_output_frequency(self, f_target, pwr=31, solution=None, en_b=False):
+        # We only support integer mode right now
+        self.MASH_ORDER.value = 0
+        self.MASH_RESET_N.set(self.MASH_RESET_N.RESET)
+        self.PLL_NUM.value = 0
+        self.PLL_DEN.value = 0
+
+        self.OUTA_PWR.value = pwr
+        self.OUTA_PD.set(self.OUTA_PD.NORMAL_OPERATION)
+        if en_b:
+            self.OUTB_PWR.value = 31
+            self.OUTB_PD.set(self.OUTB_PD.NORMAL_OPERATION)
+        else:
+            self.OUTB_PWR.value = 0
+            self.OUTB_PD.set(self.OUTB_PD.POWERDOWN)
+
+        chdivs = []
+        f_vco_min = 7500
+
+        for i,(div,f_vco_max,f_out_min,f_out_max) in enumerate(CHDIV_TABLE):
+            if not (f_out_min <= f_target <= f_out_max):
+                continue
+
+            f_vco = f_target * div
+
+            if not (f_vco_min <= f_vco <= f_vco_max):
+                continue
+
+            chdivs.append((i, div, f_vco))
+
+        if len(chdivs) < 1:
+            raise RuntimeError("No possible integer solutions found!")
+
+        solutions = []
+        print("  i |   f_vco  | DIV | MIN_N | DLY_SEL |   n  |   R  | R_pre |  f_pfd  |   f_out  | Delta f |   Metric   ")
+        print("----|----------|-----|-------|---------|------|------|-------|---------|----------|---------|------------")
+
+        metric_min = np.inf
+        metric_min_idx = None
+        for idx,(i,div,f_vco) in enumerate(chdivs):
+            min_n,dly_sel = LMX2594.get_modulator_constraints(self.MASH_ORDER.value, f_vco)
+
+            ratio = fractions.Fraction(f_vco / self.f_osc).limit_denominator(255)
+            n = ratio.numerator
+            R = ratio.denominator
+
+            R_pre = 1
+
+            assert n != 0, "N can't be zero!"
+
+            while n < min_n or self.f_osc / (R * R_pre) > 400:
+                n *= 2
+
+                if R*2 <= 255:
+                    R *= 2
+                elif R_pre * 2 < 128:
+                    R_pre *= 2
+                else:
+                    raise RuntimeError("Failed to find solution, N limit can't be met!")
+
+            f_pd = self.f_osc / (R * R_pre)
+
+            metric = R_pre * R * n * div
+            if metric < metric_min:
+                metric_min_idx = idx
+                metric_min = metric
+
+            f_out = f_vco / div
+            delta_f = abs(f_out - f_target)
+
+            metric += delta_f*1e6
+
+            print(f" {idx:>2d} | {f_vco:8.2f} | {div:3d} | {min_n:5d} | {dly_sel:7d} | {n:4d} | {R:4d} | {R_pre:5d} | {f_pd:7.2f} | {f_out:8.2f} | {delta_f:7.2f} | {metric:6.4e}")
+
+            solutions.append((i, div, f_vco, n, R, R_pre))
+
+        print()
+        if solution is None:
+            print(f"Choosing solution {metric_min_idx} with minimal metric {metric_min}.")
+            solution = metric_min_idx
+
+        chdiv_i,chdiv,f_vco,n,R,R_pre = solutions[solution]
+
+        self.CHDIV.value = chdiv_i % 18
+        self.PFD_DLY_SEL.value = dly_sel
+        self.PLL_N.value = n
+        self.PLL_N.value = n
+        self.PLL_R_PRE.value = R_pre
+        self.PLL_R.value = R
+
+        if chdiv_i == 18:
+            self.OUTA_MUX.set(self.OUTA_MUX.VCO)
+            self.OUTB_MUX.set(self.OUTB_MUX.VCO)
+            self.CHDIV_DIV2.set(self.CHDIV_DIV2.DISABLED)
+        else:
+            self.OUTA_MUX.set(self.OUTA_MUX.CHANNEL_DIVIDER)
+            self.OUTB_MUX.set(self.OUTB_MUX.CHANNEL_DIVIDER)
+
+            # Enable CHDIV_DIV2 driver for CHDIV > 2
+            self.CHDIV_DIV2.set(self.CHDIV_DIV2.DISABLED if chdiv_i == 0 else self.CHDIV_DIV2.ENABLED)
+
+        self.update()
+        self.configure_calibration()
+
+        return f_vco / chdiv
+
+    def configure_calibration(self, assistance_level=0):
+        if self.f_pd <= 100:
+            if self.f_pd >= 10:
+                self.FCAL_LPFD_ADJ.value = 0
+            elif self.f_pd >= 5:
+                self.FCAL_LPFD_ADJ.value = 1
+            elif self.f_pd >= 2.5:
+                self.FCAL_LPFD_ADJ.value = 2
+            else:
+                self.FCAL_LPFD_ADJ.value = 3
+
+            self.FCAL_HPFD_ADJ.value = 0
+        elif self.f_pd <= 150:
+            self.FCAL_HPFD_ADJ.value = 1
+        elif self.f_pd <= 200:
+            self.FCAL_HPFD_ADJ.value = 2
+        else:
+            self.FCAL_HPFD_ADJ.value = 3
+
+        # Optimize for phase noise performance (At the cost of locking time)
+        self.CAL_CLK_DIV.value = 3
+        self.ACAL_CMP_DLY.value = 25
+
+        # Don't output clock signal during calibration
+        self.OUT_MUTE.value = 1
+        self.OUT_FORCE.value = 0
+
+        # VCO calibration settings
+        if 11900 <= self.f_vco <= 12100:
+            self.VCO_SEL.value = 4
+            self.QUICK_RECAL_EN.value = 0
+            self.VCO_SEL_FORCE.value = 0
+            self.VCO_DACISET_FORCE.value = 0
+            self.VCO_CAPCTRL_FORCE.value = 0
+
+            self.VCO_DACISET_STRT.value = 300
+            self.VCO_CAPCTRL_STRT.value = 183 
+
+        elif assistance_level == CAL_NO_ASSIST:
+            self.QUICK_RECAL_EN.value = 0
+            self.VCO_SEL_FORCE.value = 0
+            self.VCO_DACISET_FORCE.value = 0
+            self.VCO_CAPCTRL_FORCE.value = 0
+            self.VCO_SEL.value = 7
+
+        else:
+            for vco_id, f_min, f_max, c_min, c_max, a_min, a_max in LMX2594_VCOs:
+                if f_min <= self.f_vco <= f_max:
+                    self.VCO_SEL.value = vco_id
+                    self.VCO_DACISET_STRT.value = round(c_min - (c_min - c_max) * (f_vco - f_min) / (f_max - f_min))
+                    self.VCO_CAPCTRL_STRT.value = round(a_min + (a_max - a_min) * (f_vco - f_min) / (f_max - f_min))
+                    break
+
+                if vco_id == 7:
+                    raise RuntimeError("Failed to find acceptable VCO??")
+
+            if assistance_level == CAL_PARTIAL_ASSIST:
+                self.QUICK_RECAL_EN.value = 0
+                self.VCO_SEL_FORCE.value = 0
+                self.VCO_DACISET_FORCE.value = 0
+                self.VCO_CAPCTRL_FORCE.value = 0
+
+            elif assistance_level == CAL_CLOSE_FREQUENCY_ASSIST:
+                self.QUICK_RECAL_EN.value = 1
+                self.VCO_SEL_FORCE.value = 0
+                self.VCO_DACISET_FORCE.value = 0
+                self.VCO_CAPCTRL_FORCE.value = 0
+
+            elif assistance_level == CAL_FULL_ASSIST:
+                self.QUICK_RECAL_EN.value = 0
+                self.VCO_SEL_FORCE.value = 1
+                self.VCO_DACISET_FORCE.value = 1
+                self.VCO_CAPCTRL_FORCE.value = 1
+
+    def get_modulator_constraints(mash_order, f_vco):
+        if mash_order == 0:
+            if f_vco <= 12500:
+                min_n = 28
+                dly_sel = 1
+            else:
+                min_n = 32
+                dly_sel = 2
+        elif mash_order == 1:
+            if f_vco <= 10000:
+                min_n = 28
+                dly_sel = 1
+            elif 10000 < f_vco < 12500:
+                min_n = 32
+                dly_sel = 2
+            else:
+                min_n = 36
+                dly_sel = 3
+        elif mash_order == 2:
+            if f_vco <= 10000:
+                min_n = 32
+                dly_sel = 2
+            else:
+                min_n = 36
+                dly_sel = 3
+        elif mash_order == 3:
+            if f_vco <= 10000:
+                min_n = 36
+                dly_sel = 3
+            else:
+                min_n = 40
+                dly_sel = 4
+        elif mash_order == 4:
+            if f_vco <= 10000:
+                min_n = 44
+                dly_sel = 5
+            else:
+                min_n = 48
+                dly_sel = 6
+        else:
+            raise RuntimeError(f"Can't handle unknown mash order: {mash_order}")
+
+        return min_n, dly_sel
+
+    def update(self):
+        if self.OSC_2X.get() == self.OSC_2X.DISABLED:
+            f_in = self.f_osc
+        else:
+            f_in = 2 * self.f_osc
+
+        f_in /= self.PLL_R_PRE.value
+        f_in *= self.MULT.value
+        f_in /= self.PLL_R.value
+
+        self.f_pd = f_in
+
+        num = self.PLL_NUM.value
+        den = self.PLL_DEN.value
+        pll_n = self.PLL_N.value
+
+        if den != 0 and num != 0:
+            self.f_vco = self.f_pd * (pll_n + num/den)
+        else:
+            self.f_vco = self.f_pd * pll_n
+
+        if not (7500 <= self.f_vco <= 15000):
+            raise RuntimeError(f"VCO frequency f_vco = {round(self.f_vco, ndigits=2)} out of range: 7500 MHz <= f_vco <= 15000")
+
+        self.f_chdiv = self.f_vco / CHDIV_TABLE[self.CHDIV.value][0]
+
+        if self.OUTA_MUX.get() == self.OUTA_MUX.CHANNEL_DIVIDER:
+            self.f_outa = self.f_chdiv
+        else:
+            self.f_outa = self.f_vco
+
+        sysref_divider_lut = { self.SYSREF_DIV_PRE.DIVIDE_BY_1: 1,
+                               self.SYSREF_DIV_PRE.DIVIDE_BY_2: 2,
+                               self.SYSREF_DIV_PRE.DIVIDE_BY_4: 4 }
+        
+        if self.SYSREF_EN.get() == self.SYSREF_EN.ENABLED:
+            sysref_div = self.SYSREF_DIV.get()
+            sysref_div *= sysref_divider_lut[self.SYSREF_DIV_PRE.get()]
+            self.f_sysref = self.f_vco / sysref_div
+
+        outb_mux = self.OUTB_MUX.get()
+        if outb_mux == self.OUTB_MUX.CHANNEL_DIVIDER:
+            self.f_outb = self.f_chdiv
+        elif outb_mux == self.OUTB_MUX.VCO or outb_mux == self.OUTB_MUX.HIGH_IMPEDANCE:
+            self.f_outb = self.f_vco
+        elif outb_mux == self.SYSREF:
+            self.f_outb = self.f_sysref
+
+class LMK04828BOutputBranch:
+    def __init__(self, parent, i):
+        self.parent = parent
+        self.i = i
+
+        def ga(n):
+            return getattr(self.parent, n)
+
+        self.DIV = ga(f"DCLKout{self.i}_DIV")
+        self.CLK_PD = ga(f"CLKout{self.i}_{self.i+1}_PD")
+        self.SDCLK_PD = ga(f"SDCLKout{self.i+1}_PD")
+        self.DCLK_FMT = ga(f"DCLKout{self.i}_FMT")
+        self.SDCLK_FMT = ga(f"SDCLKout{self.i+1}_FMT")
+        self.DCLK_POL = ga(f"DCLKout{self.i}_POL")
+        self.SDCLK_POL = ga(f"SDCLKout{self.i+1}_POL")
+
+        self.DCLK_MUX = ga(f"DCLKout{self.i}_MUX")
+        self.SDCLK_MUX = ga(f"SDCLKout{self.i+1}_MUX")
+
+    def _set_output_status(self, dclk_enable, sdclk_enable):
+        if not dclk_enable and not sdclk_enable:
+            self.CLK_PD.set(self.CLK_PD.POWERDOWN)
+        elif dclk_enable and not sdclk_enable:
+            self.CLK_PD.set(self.CLK_PD.ENABLED)
+            self.DCLK_FMT.set(self.DCLK_FMT.LVDS)
+            self.SDCLK_PD.set(self.SDCLK_PD.POWERDOWN)
+        elif not dclk_enable and sdclk_enable:
+            self.CLK_PD.set(self.CLK_PD.ENABLED)
+            self.DCLK_FMT.set(self.DCLK_FMT.POWERDOWN)
+            self.SDCLK_FMT.set(self.SDCLK_FMT.LVDS)
+            self.SDCLK_PD.set(self.SDCLK_PD.ENABLED)
+        elif dclk_enable and sdclk_enable:
+            self.CLK_PD.set(self.CLK_PD.ENABLED)
+            self.DCLK_FMT.set(self.DCLK_FMT.LVDS)
+            self.SDCLK_FMT.set(self.SDCLK_FMT.LVDS)
+            self.SDCLK_PD.set(self.SDCLK_PD.ENABLED)
+        else:
+            raise RuntimeError("?!")
+
+    @property
+    def dclk_active(self):
+        return not (self.dclk_fmt == self.DCLK_FMT.POWERDOWN or self.clk_pd == self.CLK_PD.POWERDOWN)
+
+    @dclk_active.setter
+    def dclk_active(self, value: bool):
+        if self.dclk_active == value:
+            return
+
+        self._set_output_status(value, self.sdclk_active)
+        self.parent.update()
+
+    @property
+    def sdclk_active(self):
+        return not (self.sdclk_pd == self.SDCLK_PD.POWERDOWN or self.sdclk_fmt == self.SDCLK_FMT.POWERDOWN or self.clk_pd == self.CLK_PD.POWERDOWN)
+
+    @sdclk_active.setter
+    def sdclk_active(self, value: bool):
+        if self.sdclk_active == value:
+            return
+
+        self._set_output_status(self.dclk_active, value)
+        self.parent.update()
+
+    def get_sdclk_freqs(self):
+        return self.parent.pll2_output_freq / (np.arange(32)+1)
+
+    def request_freq(self, value, ignore_warning=False):
+        _div = self.parent.pll2_output_freq / value
+        div = max(1, min(32, round(_div)))
+
+        f_real = self.parent.pll2_output_freq / div
+
+        if abs(div - _div) > 0.01 and not ignore_warning:
+            print(f"WARNING: Failed to hit requested frequency of {value:.2f} MHz. Using divider {div} where {_div:.3f} would have been required, thus resulting in output frequency {f_real:.2f} MHz or a frequency error of {f_real - value:.2f} MHz!")
+
+        self.DIV.value = 0x1f & div # 32 maps to 0
+        self.update()
+
+        return self.parent.pll2_output_freq / div
+
+    def update(self, printDebug=False):
+        def dbg(*s):
+            if printDebug:
+                print(f"Output Branch {self.i:2d}", *s)
+
+        self.div = self.DIV.get()
+        if self.div == 0: # 0 means 32
+            self.div = 32
+
+        dbg(f"DIV: {self.div}")
+
+        self.clk_pd = self.CLK_PD.get()
+        dbg("CLK_PD:", self.clk_pd)
+
+        self.sdclk_pd = self.SDCLK_PD.get()
+        dbg("SDCLK_PD:", self.sdclk_pd)
+
+        self.dclk_fmt = self.DCLK_FMT.get()
+        dbg("DCLK_FMT:", self.dclk_fmt)
+
+        self.sdclk_fmt = self.SDCLK_FMT.get()
+        dbg("SDCLK_FMT:", self.sdclk_fmt)
+
+        self.dclk_pol = self.DCLK_POL.get()
+        dbg("DCLK_POL:", self.dclk_pol)
+
+        self.sdclk_pol = self.SDCLK_POL.get()
+        dbg("SDCLK_POL:", self.sdclk_pol)
+
+        self.sdclk_mux = self.SDCLK_MUX.get()
+        dbg("SDCLK_MUX:", self.sdclk_mux)
+
+        self.dclk_mux = self.DCLK_MUX.get()
+        dbg("DCLK_MUX:", self.dclk_mux)
+
+        pll_freq = self.parent.pll2_output_freq
+        sysref_freq = self.parent.sysref_freq
+
+        if self.dclk_mux == self.DCLK_MUX.BYPASS:
+            self.dclk_freq = pll_freq
+        else:
+            self.dclk_freq = pll_freq / self.div
+
+        if self.sdclk_mux == self.SDCLK_MUX.DEVICE_CLOCK_OUTPUT:
+            self.sdclk_freq = self.dclk_freq
+        else:
+            self.sdclk_freq = sysref_freq
+
+        dbg("DCLK_FREQ:", round(self.dclk_freq, ndigits=2))
+        dbg("SDCLK_FREQ:", round(self.sdclk_freq, ndigits=2))
+
+        dbg("DCLK_ACTIVE:", self.dclk_active)
+        dbg("SDCLK_ACTIVE:", self.sdclk_active)
+
+class LMK04828B(RegisterDevice):
+    def __init__(self, clkin0_freq, clkin1_freq, clkin2_freq, vcxo_freq):
+        RegisterDevice.__init__(self, 13, 8, "data/lmk04828b_regmap.json")
+
+        self.clkin0_freq = clkin0_freq
+        self.clkin1_freq = clkin1_freq
+        self.clkin2_freq = clkin2_freq
+        self.vcxo_freq = vcxo_freq
+
+        # Dictionaries are unordered, and because the order of operations is important when writing
+        # these registers, the correct order of indices is written down in this array:
+        self.register_addresses = [0, 2, 3, 4, 5, 6, 12, 13, 256, 257, 258, 259, 260, 261, 262,
+                                   263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275,
+                                   276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288,
+                                   289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301,
+                                   302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314,
+                                   315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327,
+                                   328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340,
+                                   341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353,
+                                   354, 355, 356, 357, 369, 370, 380, 381, 358, 359, 360, 361, 362,
+                                   363, 364, 365, 366, 371, 386, 387, 388, 389, 392, 393, 394, 395,
+                                   8189, 8190, 8191]
+
+        self.clock_branches = [LMK04828BOutputBranch(self, 2*i) for i in range(7)]
+
+    def write_register_dump(self, name):
+        with open(name, "w") as f:
+            f.write(f"R0 (INIT)\t0x000090\n")
+
+            for addr,val in self.get_register_dump(with_addr=True):
+                f.write(f"R{addr}\t0x{val:06X}\n")
+
+    def update(self, printDebug=False):
+        def dbg(*s):
+            if printDebug:
+                print(*s)
+
+        sel_mode = self.CLKin_SEL_MODE.get()
+
+        dbg("SEL_MODE:", self.CLKin_SEL_MODE.get())
+
+        if sel_mode == self.CLKin_SEL_MODE.CLK_IN_0_MANUAL:
+            assert self.CLKin0_OUT_MUX.get() == self.CLKin0_OUT_MUX.PLL1
+            pll1_src_freq = self.clkin0_freq
+
+            divider = self.CLKin0_R.value
+
+        elif sel_mode == self.CLKin_SEL_MODE.CLK_IN_1_MANUAL:
+            assert self.CLKin1_OUT_MUX.get() == self.CLKin1_OUT_MUX.PLL1
+            pll1_src_freq = self.clkin1_freq
+
+            divider = self.CLKin1_R.value
+
+        elif sel_mode == self.CLKin_SEL_MODE.CLK_IN_2_MANUAL:
+            assert self.CLKin2_OUT_MUX.get() == self.CLKin2_OUT_MUX.PLL1
+            pll1_src_freq = self.clkin2_freq
+
+            divider = self.CLKin2_R.value
+        else:
+            raise RuntimeError("sel_mode == " + str(sel_mode) + ", which is not supported!")
+
+        dbg("Input divider:", divider)
+
+        assert self.PLL1_NCLK_MUX.get() == self.PLL1_NCLK_MUX.OSC_IN, "Only configurations using the external VCXO are supported!"
+
+        self.pll1_phase_detector_freq = pll1_src_freq / divider
+        dbg("PLL1 Phase Detector Frequency:", self.pll1_phase_detector_freq)
+
+        self.pll1_n_divider = self.PLL1_N.value
+        dbg("PLL1N Divider:", self.pll1_n_divider)
+        dbg("Expected VCXO Frequency:", self.pll1_n_divider * self.pll1_phase_detector_freq)
+
+        assert self.vcxo_freq == self.pll1_n_divider * self.pll1_phase_detector_freq
+
+        self.pll2_r_divider = self.PLL2_R.value
+        pll2_input_freq = self.vcxo_freq / self.pll2_r_divider * (2 if self.PLL2_REF_2X_EN.get() == self.PLL2_REF_2X_EN.ENABLED else 1)
+        dbg("PLL2 Input Frequency:", pll2_input_freq)
+
+        assert self.PLL2_NCLK_MUX.get() == self.PLL2_NCLK_MUX.PLL_PRESCALER, "Only configurations using PLL2 feedback from prescaler are supported!"
+
+        pll2_p_raw = self.PLL2_P.get()
+        if pll2_p_raw == self.PLL2_P.DIVIDE_2 or pll2_p_raw == self.PLL2_P.DIVIDE_2_2:
+            pll2_p = 2
+        elif pll2_p_raw == self.PLL2_P.DIVIDE_8:
+            pll2_p = 8
+        else:
+            pll2_p = self.PLL2_P.value
+
+        dbg("PLL2_P:", pll2_p)
+
+        pll2_n = self.PLL2_N.value
+        dbg("PLL2_N:", pll2_n)
+
+        self.pll2_output_freq = pll2_input_freq * pll2_n * pll2_p
+        dbg("PLL2 Output Frequency:", round(self.pll2_output_freq, ndigits=2))
+
+        self.sysref_divider = self.SYSREF_DIV.value
+        dbg("SYSREF DIVIDER:", self.sysref_divider)
+
+        self.sysref_freq = self.pll2_output_freq / self.sysref_divider
+        dbg("SYSREF FREQ:", round(self.sysref_freq, ndigits=5))
+
+        for branch in self.clock_branches:
+            branch.update(printDebug)
+
+    def set_refclk(self, refclk, precision=1):
+        f_i = int(self.vcxo_freq * 10**precision)
+
+        if 2370 < refclk < 2630:
+            vco = 0 # VCO0
+        elif 2920 < refclk < 3080:
+            vco = 1 # VCO1
+        else:
+            raise RuntimeError("Requested VCO frequency is not compatible with either VCO")
+
+        refclk = int(refclk * 10**precision)
+
+        div = np.gcd(f_i, refclk)
+
+        R = f_i // div
+        N = refclk // div
+
+        if self.vcxo_freq // R > 150:
+            print("Phase detector frequency too high, introducing factor")
+            fac = np.ceil((self.vcxo_freq // R) / 150)
+            R *= fac
+            N *= fac
+
+        success = False
+        for P in range(2, 9): # Absorb part of N into the prescaler
+            if N % P == 0:
+                success = True
+                break
+
+        if not success:
+            raise RuntimeError("Failed to find suitable solution!")
+
+        self.VCO_MUX.value = self.VCO_MUX.VCO_1.value if vco == 1 else self.VCO_MUX.VCO_0.value
+
+        self.PLL2_R.value = R
+        self.PLL2_N.value = N // P
+        self.PLL2_P.value = P & 0x7 # 8 is represented as 0
+
+        self.update()
+
+        return R, N // P, P
+
+    def set_sysref(self, value):
+        _div = self.pll2_output_freq / value
+        div = min(8191, max(8, int(round(_div))))
+
+        f_new = self.pll2_output_freq / div
+
+        if abs(div - _div) / div > 0.01:
+            print(f"WARNING: SYSREF_CLK target could not be hit accurately! Requested frequency {value} MHz requires divider {_div:.4f} which is not realizable. The closest integer divider {div} results in a frequency of {f_new} MHz!")
+
+        self.SYSREF_DIV.value = div
+        self.update()
+
+class CLK104Output:
+    def __init__(self, branch):
+        self.branch = branch
+
+    @property
+    def freq(self):
+        return self.branch.dclk_freq
+
+    @freq.setter
+    def freq(self, value):
+        return self.branch.request_freq(value)
+
+    @property
+    def sysref_freq(self):
+        return self.branch.sdclk_freq
+
+    @property
+    def enable(self):
+        return self.branch.dclk_active
+
+    @property
+    def sysref_enable(self):
+        return self.branch.sdclk_active
+
+    @enable.setter
+    def enable(self, value):
+        self.branch.dclk_active = value
+
+    @sysref_enable.setter
+    def sysref_enable(self, value):
+        self.branch.sdclk_active = value
+
+class CLK104:
+    def __init__(self, src=None):
+        # 10 MHz reference clock, 10 MHz clock input on external SMA, 160 MHz VCO frequency
+        self.lmk = LMK04828B(10, 10, 10, 160)
+        self.lmx_adc = LMX2594(245.76)
+        self.lmx_dac = LMX2594(245.76)
+
+        if src is None:
+            with files("ipq_pynq_utils").joinpath("data/lmk04828b_regdump_defaults.txt").open() as f:
+                self.lmk.init_from_file(f)
+        else:
+            self.lmk.init_from_file(src)
+
+        with files("ipq_pynq_utils").joinpath("data/clockFiles/LMX2594_REF-245M76__OUT-9830M40_10172019_I.txt").open() as f:
+            self.lmx_adc.init_from_file(f)
+
+        with files("ipq_pynq_utils").joinpath("data/clockFiles/LMX2594_REF-245M76__OUT-9830M40_10172019_I.txt").open() as f:
+            self.lmx_dac.init_from_file(f)
+
+        self.RF_PLL_ADC_REF = CLK104Output(self.lmk.clock_branches[0])
+        self.AMS_SYSREF = CLK104Output(self.lmk.clock_branches[1])
+        self.RF_PLL_DAC_REF = CLK104Output(self.lmk.clock_branches[2])
+        self.DAC_REFCLK = CLK104Output(self.lmk.clock_branches[3])
+        self.PL_CLK = CLK104Output(self.lmk.clock_branches[4])
+        self.EXT_REF_OUT = CLK104Output(self.lmk.clock_branches[5])
+        self.ADC_REFCLK = CLK104Output(self.lmk.clock_branches[6])
+
+    @property
+    def PLL2_FREQ(self):
+        return self.lmk.pll2_output_freq
+
+    @PLL2_FREQ.setter
+    def PLL2_FREQ(self, value):
+        self.lmk.set_refclk(value)
+
+    @property
+    def SYSREF_FREQ(self):
+        return self.lmk.sysref_freq
+
+    @SYSREF_FREQ.setter
+    def SYSREF_FREQ(self, value):
+        self.lmk.set_sysref(value)
+
+    def get_register_dump(self):
+        return {
+                "LMK": self.lmk.get_register_dump()
+                }

--- a/qick_lib/qick/ipq_pynq_utils/lmx2594_regmap.json
+++ b/qick_lib/qick/ipq_pynq_utils/lmx2594_regmap.json
@@ -1,0 +1,3138 @@
+[
+    {
+        "addr": 0,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 15,
+                "name": "RAMP_EN",
+                "description": "Control frequency ramping mode.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLE",
+                            "description": "Disable frequency ramping mode"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLE",
+                            "description": "Enable frequency ramping mode"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 14,
+                "start": 14,
+                "name": "VCO_PHASE_SYNC",
+                "description": "Control phase synchronization.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disable phase SYNC mode"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enable phase SYNC mode"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 9,
+                "start": 9,
+                "name": "OUT_MUTE",
+                "description": "Mute the outputs when the VCO is calibrating.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled. If disabled, also be sure to enable OUT_FORCE"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled. If enabled, also be sure to disable OUT_FORCE"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 8,
+                "start": 7,
+                "name": "FCAL_HPFD_ADJ",
+                "description": "Set this field in accordance to the phase-detector frequency for optimal VCO calibration.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "F_PD_LTE_100_MHZ",
+                            "description": "f_PD <= 100 MHz"
+                        },
+                        {
+                            "value": 1,
+                            "name": "F_PD_100_MHZ_TO_150_MHZ",
+                            "description": "100 MHz < f_PD <= 150 MHz"
+                        },
+                        {
+                            "value": 2,
+                            "name": "F_PD_150_MHZ_TO_200_MHZ",
+                            "description": "150 MHz < f_PD <= 200 MHz"
+                        },
+                        {
+                            "value": 3,
+                            "name": "F_PD_GT_200_MHZ",
+                            "description": "f_PD > 200 MHz"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 6,
+                "start": 5,
+                "name": "FCAL_LPFD_ADJ",
+                "description": "Set this field in accordance to the phase detector frequency for optimal VCO calibration.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "F_PD_GTE_10_MHZ",
+                            "description": "f_PD >= 10 MHz"
+                        },
+                        {
+                            "value": 1,
+                            "name": "F_PD_10_MHZ_TO_5_MHZ",
+                            "description": "10 MHz > f_PD >= 5 MHz"
+                        },
+                        {
+                            "value": 2,
+                            "name": "F_PD_5_MHZ_TO_2_5_MHZ",
+                            "description": "5 MHz > f_PD >= 2.5 MHz"
+                        },
+                        {
+                            "value": 3,
+                            "name": "F_PD_LT_2_5_MHZ",
+                            "description": "f_PD < 2.5 MHz"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 3,
+                "start": 3,
+                "name": "FCAL_EN",
+                "description": "Enable the VCO frequency calibration. Also note that the action of programming this bit to a 1 activates the VCO calibration",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": "0",
+                            "name": "DISABLED",
+                            "description": "VCO frequency calibration disabled."
+                        },
+                        {
+                            "value": "1",
+                            "name": "ENABLED",
+                            "description": "VCO frequency calibration enabled."
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 2,
+                "start": 2,
+                "name": "MUXOUT_LD_SEL",
+                "description": "Selects the state of the function of the MUXout pin",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "READBACK",
+                            "description": "Readback"
+                        },
+                        {
+                            "value": 1,
+                            "name": "LOCK_DETECT",
+                            "description": "Lock detect"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 1,
+                "start": 1,
+                "name": "RESET",
+                "description": "Resets and holds all state machines and registers to default value.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "NORMAL_OPERATION",
+                            "description": "Normal operation"
+                        },
+                        {
+                            "value": 1,
+                            "name": "RESET",
+                            "description": "Reset active"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 0,
+                "start": 0,
+                "name": "POWERDOWN",
+                "description": "Powers down entire device",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "NORMAL_OPERATION",
+                            "description": "Normal operation"
+                        },
+                        {
+                            "value": 1,
+                            "name": "POWERDOWN",
+                            "description": "Powered down"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 9232
+            }
+        ]
+    },
+    {
+        "addr": 1,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 2,
+                "start": 0,
+                "name": "CAL_CLK_DIV",
+                "description": "Sets divider for VCO calibration state machine clock based on input frequency. If user is not concerned with lock time, it is recommended to set this value to 3. By slowing down the VCO calibration, the best and most repeatable VCO phase noise can be attained.",
+                "default": 3,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DIVIDE_BY_1",
+                            "description": "Divide by 1. Use for fOSC ≤ 200 MHz"
+                        },
+                        {
+                            "value": 1,
+                            "name": "DIVIDE_BY_2",
+                            "description": "Divide by 2. Use for fOSC ≤ 400 MHz"
+                        },
+                        {
+                            "value": 2,
+                            "name": "DIVIDE_BY_4",
+                            "description": "Divide by 4. Use for fOSC ≤ 800 MHz"
+                        },
+                        {
+                            "value": 3,
+                            "name": "DIVIDE_BY_8",
+                            "description": "Divide by 8. All fOSC"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 2056
+            }
+        ]
+    },
+    {
+        "addr": 2,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1280
+            }
+        ]
+    },
+    {
+        "addr": 3,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1602
+            }
+        ]
+    },
+    {
+        "addr": 4,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 8,
+                "name": "ACAL_CMP_DLY",
+                "description": "VCO amplitude calibration delay. Lowering this value can speed up VCO calibration, but lowering it too much may degrade VCO phase noise. The minimum allowable value for this field is 10 and this allows the VCO to calibrate to the correct frequency for all scenarios. To yield the best and most repeatable VCO phase noise, this relationship should be met: ACAL_CMP_DLY > Fsmclk / 10 MHz, where Fsmclk = Fosc / 2^(CAL_CLK_DIV) and Fosc is the input reference frequency. If calibration time is of concern, then it is recommended to set this register to ≥ 25.",
+                "default": 10,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 67
+            }
+        ]
+    },
+    {
+        "addr": 5,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 200
+            }
+        ]
+    },
+    {
+        "addr": 6,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 51202
+            }
+        ]
+    },
+    {
+        "addr": 7,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 14,
+                "start": 14,
+                "name": "OUT_FORCE",
+                "description": "Works with OUT_MUTE in disabling outputs when VCO calibrating.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "OUTPUT_ENABLE_NOT_FORCED",
+                            "description": "Output not forced"
+                        },
+                        {
+                            "value": 1,
+                            "name": "OUTPUT_ENABLE_FORCED",
+                            "description": "Enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 178
+            }
+        ]
+    },
+    {
+        "addr": 8,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 14,
+                "start": 14,
+                "name": "VCO_DACISET_FORCE",
+                "description": "This forces the VCO_DACISET value",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 11,
+                "start": 11,
+                "name": "VCO_CAPCTRL_FORCE",
+                "description": "This forces the VCO_CAPCTRL value",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 8192
+            }
+        ]
+    },
+    {
+        "addr": 9,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 12,
+                "start": 12,
+                "name": "OSC_2X",
+                "description": "Low noise OSCin frequency doubler.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Frequency doubler disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Frequency doubler enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1540
+            }
+        ]
+    },
+    {
+        "addr": 10,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 11,
+                "start": 7,
+                "name": "MULT",
+                "description": "Programmable input frequency multiplier 0,2,,8-31: Reserved, 1: Byapss, 3: 3X ... 7: 7X",
+                "default": 1,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 4184
+            }
+        ]
+    },
+    {
+        "addr": 11,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 11,
+                "start": 4,
+                "name": "PLL_R",
+                "description": "Programmable input path divider after the programmable input frequency multiplier.",
+                "default": 1,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 8
+            }
+        ]
+    },
+    {
+        "addr": 12,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 11,
+                "start": 0,
+                "name": "PLL_R_PRE",
+                "description": "Programmable input path divider before the programmable input frequency multiplier.",
+                "default": 1,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 20480
+            }
+        ]
+    },
+    {
+        "addr": 13,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 16384
+            }
+        ]
+    },
+    {
+        "addr": 14,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 6,
+                "start": 4,
+                "name": "CPG",
+                "description": "Effective charge-pump current. This is the sum of up and down currents.",
+                "default": 7,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "CPC_0_mA",
+                            "description": "0 mA"
+                        },
+                        {
+                            "value": 1,
+                            "name": "CPC_6_mA",
+                            "description": "6 mA"
+                        },
+                        {
+                            "value": 3,
+                            "name": "CPC_12_mA",
+                            "description": "12 mA"
+                        },
+                        {
+                            "value": 4,
+                            "name": "CPC_3_mA",
+                            "description": "3 mA"
+                        },
+                        {
+                            "value": 5,
+                            "name": "CPC_9_mA",
+                            "description": "9 mA"
+                        },
+                        {
+                            "value": 7,
+                            "name": "CPC_15_mA",
+                            "description": "15 mA"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 7680
+            }
+        ]
+    },
+    {
+        "addr": 15,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1615
+            }
+        ]
+    },
+    {
+        "addr": 16,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 8,
+                "start": 0,
+                "name": "VCO_DACISET",
+                "description": "This sets the final amplitude for the VCO calibration in the case that amplitude calibration is forced.",
+                "default": 128,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 17,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 8,
+                "start": 0,
+                "name": "VCO_DACISET_STRT",
+                "description": "This sets the initial starting point for the VCO amplitude calibration.",
+                "default": 250,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 18,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 100
+            }
+        ]
+    },
+    {
+        "addr": 19,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 7,
+                "start": 0,
+                "name": "VCO_CAPCTRL",
+                "description": "This sets the final VCO band when VCO_CAPCTRL is forced.",
+                "default": 183,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 9984
+            }
+        ]
+    },
+    {
+        "addr": 20,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 13,
+                "start": 11,
+                "name": "VCO_SEL",
+                "description": "This sets VCO start core for calibration and the VCO when it is forced.",
+                "default": 7,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "NOT_USED",
+                            "description": "Not used."
+                        },
+                        {
+                            "value": 1,
+                            "name": "VCO1",
+                            "description": "VCO1"
+                        },
+                        {
+                            "value": 2,
+                            "name": "VCO2",
+                            "description": "VCO2"
+                        },
+                        {
+                            "value": 3,
+                            "name": "VCO3",
+                            "description": "VCO3"
+                        },
+                        {
+                            "value": 4,
+                            "name": "VCO4",
+                            "description": "VCO4"
+                        },
+                        {
+                            "value": 5,
+                            "name": "VCO5",
+                            "description": "VCO5"
+                        },
+                        {
+                            "value": 6,
+                            "name": "VCO6",
+                            "description": "VCO6"
+                        },
+                        {
+                            "value": 7,
+                            "name": "VCO7",
+                            "description": "VCO7"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 10,
+                "start": 10,
+                "name": "VCO_SEL_FORCE",
+                "description": "This forces the VCO to use the core specified by VCO_SEL. It is intended mainly for diagnostic purposes.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled (recommended)"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 49224
+            }
+        ]
+    },
+    {
+        "addr": 21,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1025
+            }
+        ]
+    },
+    {
+        "addr": 22,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1
+            }
+        ]
+    },
+    {
+        "addr": 23,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 124
+            }
+        ]
+    },
+    {
+        "addr": 24,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1818
+            }
+        ]
+    },
+    {
+        "addr": 25,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 3115
+            }
+        ]
+    },
+    {
+        "addr": 26,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 3504
+            }
+        ]
+    },
+    {
+        "addr": 27,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 2
+            }
+        ]
+    },
+    {
+        "addr": 28,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1160
+            }
+        ]
+    },
+    {
+        "addr": 29,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 12684
+            }
+        ]
+    },
+    {
+        "addr": 30,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 12684
+            }
+        ]
+    },
+    {
+        "addr": 31,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 14,
+                "start": 14,
+                "name": "CHDIV_DIV2",
+                "description": "Enable driver buffer for CHDIV > 2",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled (only valid for CHDIV = 2)"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled (use for CHDIV > 2)"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1004
+            }
+        ]
+    },
+    {
+        "addr": 32,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 915
+            }
+        ]
+    },
+    {
+        "addr": 33,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 7713
+            }
+        ]
+    },
+    {
+        "addr": 34,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 2,
+                "start": 0,
+                "name": "PLL_N[18:16]",
+                "description": "The PLL_N divider value is in the feedback path and divides the VCO frequency.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 35,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 4
+            }
+        ]
+    },
+    {
+        "addr": 36,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "PLL_N[15:0]",
+                "description": "The PLL_N divider value is in the feedback path and divides the VCO frequency.",
+                "default": 100,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 37,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 15,
+                "name": "MASH_SEED_EN",
+                "description": "Enabling this bit allows the to be applied to shift the phase at the output or optimize spurs.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 13,
+                "start": 8,
+                "name": "PFD_DLY_SEL",
+                "description": "The PFD_DLY_SEL must be adjusted in accordance to the Ndivider value. This is with the functional description for the Ndivider",
+                "default": 2,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 4
+            }
+        ]
+    },
+    {
+        "addr": 38,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "PLL_DEN[31:16]",
+                "description": "The fractional denominator",
+                "default": 65535,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 39,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "PLL_DEN[15:0]",
+                "description": "The fractional denominator",
+                "default": 65535,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "NAME",
+                            "description": "Descr"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 40,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "MASH_SEED[31:16]",
+                "description": "The initial state of the MASH engine first accumulator. Can be used to shift phase or optimize fractional spurs. Every time the field is programmed, it ADDS this MASH seed to the existing one. To reset it, use the MASH_RESET_N bit.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 41,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "MASH_SEED[15:0]",
+                "description": "The initial state of the MASH engine first accumulator. Can be used to shift phase or optimize fractional spurs. Every time the field is programmed, it ADDS this MASH seed to the existing one. To reset it, use the MASH_RESET_N bit.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 42,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "PLL_NUM[31:16]",
+                "description": "The fractional numerator",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 43,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "PLL_NUM[15:0]",
+                "description": "The fractional numerator",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 44,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 13,
+                "start": 8,
+                "name": "OUTA_PWR",
+                "description": "Adjusts output power. Higher numbers give more output power to a point, depending on the pullup component used.",
+                "default": 31,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 7,
+                "start": 7,
+                "name": "OUTB_PD",
+                "description": "Powers down output B",
+                "default": 1,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "NORMAL_OPERATION",
+                            "description": "Normal operation"
+                        },
+                        {
+                            "value": 1,
+                            "name": "POWERDOWN",
+                            "description": "Powerdown"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 6,
+                "start": 6,
+                "name": "OUTA_PD",
+                "description": "Powers down output A",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "NORMAL_OPERATION",
+                            "description": "Normal operation"
+                        },
+                        {
+                            "value": 1,
+                            "name": "POWERDOWN",
+                            "description": "Powerdown"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 5,
+                "start": 5,
+                "name": "MASH_RESET_N",
+                "description": "Resets MASH circuitry to an initial state",
+                "default": 1,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "RESET",
+                            "description": "MASH held in reset. All fractions are ignored"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Fractional mode enabled. MASH is NOT held in reset."
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 2,
+                "start": 0,
+                "name": "MASH_ORDER",
+                "description": "Sets the MASH order",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "INTEGER_MODE",
+                            "description": "Integer mode"
+                        },
+                        {
+                            "value": 1,
+                            "name": "FIRST_ORDER_MODULATOR",
+                            "description": "First order modulator"
+                        },
+                        {
+                            "value": 2,
+                            "name": "SECOND_ORDER_MODULATOR",
+                            "description": "Second order modulator"
+                        },
+                        {
+                            "value": 3,
+                            "name": "THIRD_ORDER_MODULATOR",
+                            "description": "Third order modulator"
+                        },
+                        {
+                            "value": 4,
+                            "name": "FOURTH_ORDER_MODULATOR",
+                            "description": "Fourth order modulator"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 45,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 12,
+                "start": 11,
+                "name": "OUTA_MUX",
+                "description": "Selects what signal goes to RFoutA",
+                "default": 1,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "CHANNEL_DIVIDER",
+                            "description": "Channel divider"
+                        },
+                        {
+                            "value": 1,
+                            "name": "VCO",
+                            "description": "VCO"
+                        },
+                        {
+                            "value": 3,
+                            "name": "HIGH_IMPEDANCE",
+                            "description": "High impedance"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 10,
+                "start": 9,
+                "name": "OUT_ISET",
+                "description": "Setting to a lower value allows slightly higher output power at higher frequencies at the expense of higher current consumption. 0: Maximum power boost, 3: No output power boost.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 5,
+                "start": 0,
+                "name": "OUTB_PWR",
+                "description": "Output power setting for RFoutB",
+                "default": 31,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 49344
+            }
+        ]
+    },
+    {
+        "addr": 46,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 1,
+                "start": 0,
+                "name": "OUTB_MUX",
+                "description": "Selects what signal goes to RFoutB",
+                "default": 1,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "CHANNEL_DIVIDER",
+                            "description": "Channel divider"
+                        },
+                        {
+                            "value": 1,
+                            "name": "VCO",
+                            "description": "VCO"
+                        },
+                        {
+                            "value": 2,
+                            "name": "SYSREF",
+                            "description": "SysRef (also ensure SYSREF_EN=1)"
+                        },
+                        {
+                            "value": 3,
+                            "name": "HIGH_IMPEDANCE",
+                            "description": "High impedance"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 2044
+            }
+        ]
+    },
+    {
+        "addr": 47,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 768
+            }
+        ]
+    },
+    {
+        "addr": 48,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 768
+            }
+        ]
+    },
+    {
+        "addr": 49,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 16768
+            }
+        ]
+    },
+    {
+        "addr": 50,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 51,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 128
+            }
+        ]
+    },
+    {
+        "addr": 52,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 2080
+            }
+        ]
+    },
+    {
+        "addr": 53,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 54,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 55,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 56,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 57,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 32
+            }
+        ]
+    },
+    {
+        "addr": 58,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 15,
+                "name": "INPIN_IGNORE",
+                "description": "Ignore SYNC and SysRefReq Pins",
+                "default": 1,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "NORMAL_OPERATION",
+                            "description": "Pins are used. Only valid for VCO_PHASE_SYNC = 1"
+                        },
+                        {
+                            "value": 1,
+                            "name": "IGNORED",
+                            "description": "Pin is ignored"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 14,
+                "start": 14,
+                "name": "INPIN_HYST",
+                "description": "High Hysteresis for LVDS mode",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 13,
+                "start": 12,
+                "name": "INPIN_LVL",
+                "description": "Sets bias level for LVDS mode. In LVDS mode, a voltage divider can be inserted to reduce susceptibility to common-mode noise of an LVDS line because the input is single-ended. With a reasonable setup, TI recommends using INPIN_LVL = 1 (Vin) to use the entire signal swing of an LVDS line.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "VIN_DIV_4",
+                            "description": "Vin/4"
+                        },
+                        {
+                            "value": 1,
+                            "name": "VIN",
+                            "description": "Vin"
+                        },
+                        {
+                            "value": 2,
+                            "name": "VIN_DIV_2",
+                            "description": "Vin/2"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 11,
+                "start": 9,
+                "name": "INPIN_FMT",
+                "description": "IO Standard to be used for SYNC and SysRefReq pins.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "SYNC_CMOS_SYSREFREQ_CMOS",
+                            "description": "Use CMOS for both pins."
+                        },
+                        {
+                            "value": 1,
+                            "name": "SYNC_LVDS_SYSREFREQ_CMOS",
+                            "description": "Use LVDS for SYNC and CMOS for SysRefReq."
+                        },
+                        {
+                            "value": 2,
+                            "name": "SYNC_CMOS_SYSREFREQ_LVDS",
+                            "description": "Use CMOS for SYNC and LVDS for SysRefReq."
+                        },
+                        {
+                            "value": 3,
+                            "name": "SYNC_LVDS_SYSREFREQ_LVDS",
+                            "description": "Use LVDS for both pins."
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1
+            }
+        ]
+    },
+    {
+        "addr": 59,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 0,
+                "start": 0,
+                "name": "LD_TYPE",
+                "description": "Lock detect type",
+                "default": 1,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "VCO_CAL_STATUS",
+                            "description": "VCO calibration status"
+                        },
+                        {
+                            "value": 1,
+                            "name": "VCO_CAL_STATUS_AND_INDIRECT_VTUNE",
+                            "description": "VCO calibration status and Indirect Vtune"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 60,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "LD_DLY",
+                "description": "Lock Detect Delay. This is the delay added to the lock detect after the VCO calibration is successful and before the lock detect is asserted high. The delay added is in phase-detector cycles. If set to 0, the lock detect immediately becomes high after the VCO calibration is successful.",
+                "default": 1000,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 61,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 168
+            }
+        ]
+    },
+    {
+        "addr": 62,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 802
+            }
+        ]
+    },
+    {
+        "addr": 63,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 64,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 5000
+            }
+        ]
+    },
+    {
+        "addr": 65,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 66,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 500
+            }
+        ]
+    },
+    {
+        "addr": 67,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 68,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1000
+            }
+        ]
+    },
+    {
+        "addr": 69,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "MASH_RST_COUNT[31:16]",
+                "description": "If the designer does not use this device in fractional mode with VCO_PHASE_SYNC = 1, then this field can be set to 0. In phase-sync mode with fractions, this bit is used so that there is a delay for the VCO divider after the MASH is reset. This delay must be set to greater than the lock time of the PLL. It does impact the latency time of the SYNC feature.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 70,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "MASH_RST_COUNT[15:0]",
+                "description": "If the designer does not use this device in fractional mode with VCO_PHASE_SYNC = 1, then this field can be set to 0. In phase-sync mode with fractions, this bit is used so that there is a delay for the VCO divider after the MASH is reset. This delay must be set to greater than the lock time of the PLL. It does impact the latency time of the SYNC feature.",
+                "default": 50000,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 71,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 7,
+                "start": 5,
+                "name": "SYSREF_DIV_PRE",
+                "description": "Pre-divider for SYSREF",
+                "default": 4,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 1,
+                            "name": "DIVIDE_BY_1",
+                            "description": "Divide by 1"
+                        },
+                        {
+                            "value": 2,
+                            "name": "DIVIDE_BY_2",
+                            "description": "Divide by 2"
+                        },
+                        {
+                            "value": 4,
+                            "name": "DIVIDE_BY_4",
+                            "description": "Divide by 4"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 4,
+                "start": 4,
+                "name": "SYSREF_PULSE",
+                "description": "Enable pulser mode in master mode",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 3,
+                "start": 3,
+                "name": "SYSREF_EN",
+                "description": "Enable SYSREF",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 2,
+                "start": 2,
+                "name": "SYSREF_REPEAT",
+                "description": "Enable repeater mode",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "MASTER",
+                            "description": "Master mode"
+                        },
+                        {
+                            "value": 1,
+                            "name": "REPEATER",
+                            "description": "Repeater mode"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1
+            }
+        ]
+    },
+    {
+        "addr": 72,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 10,
+                "start": 0,
+                "name": "SYSREF_DIV",
+                "description": "Divider for the SYSREF. Actual divider value = regValue * 2 + 4",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 73,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 11,
+                "start": 6,
+                "name": "JESD_DAC2_CTRL",
+                "description": "These are the adjustments for the delay for the SYSREF. Two of these must be zero and the other two values must sum to 63. ",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 5,
+                "start": 0,
+                "name": "JESD_DAC1_CTRL",
+                "description": "These are the adjustments for the delay for the SYSREF. Two of these must be zero and the other two values must sum to 63. ",
+                "default": 63,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 74,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 12,
+                "name": "SYSREF_PULSE_CNT",
+                "description": "Number of pulses in pulse mode in master mode",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 11,
+                "start": 6,
+                "name": "JESD_DAC4_CTRL",
+                "description": "These are the adjustments for the delay for the SYSREF. Two of these must be zero and the other two values must sum to 63. ",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 5,
+                "start": 0,
+                "name": "JESD_DAC3_CTRL",
+                "description": "These are the adjustments for the delay for the SYSREF. Two of these must be zero and the other two values must sum to 63. ",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 75,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 10,
+                "start": 6,
+                "name": "CHDIV",
+                "description": "VCO divider value, 0: 2, 1: 4, 2: 6, 3: 8, 4: 12, 5: 16, 6: 24, 7: 32, 8: 48, 9: 64, 10: 72, 11: 96, 12: 128, 13: 192, 14: 256, 15: 384, 16: 512, 17: 768, 18-31: Reserved",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 2048
+            }
+        ]
+    },
+    {
+        "addr": 76,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 12
+            }
+        ]
+    },
+    {
+        "addr": 77,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 78,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 11,
+                "start": 11,
+                "name": "RAMP_THRESH[32:32]",
+                "description": "This sets how much the ramp can change the VCO frequency before calibrating. If this frequency is chosen to be Δf, then it is calculated as follows: RAMP_THRESH = (Δf / fPD) × 16777216",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 9,
+                "start": 9,
+                "name": "QUICK_RECAL_EN",
+                "description": "Causes the initial VCO_CORE, VCO_CAPCTRL, and VCO_DACISET to be based on the last value. Useful if the frequency change is small, as is often the case for ramping.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 8,
+                "start": 1,
+                "name": "VCO_CAPCTRL_STRT",
+                "description": "This sets the initial value for VCO_CAPCTRL if not overridden by other settings. Smaller values yield a higher frequency band within a VCO core. Valid number range is 0 to 183.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 1
+            }
+        ]
+    },
+    {
+        "addr": 79,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "RAMP_THRESH[31:16]",
+                "description": "This sets how much the ramp can change the VCO frequency before calibrating. If this frequency is chosen to be Δf, then it is calculated as follows: RAMP_THRESH = (Δf / fPD) × 16777216",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 80,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "RAMP_THRESH[15:0]",
+                "description": "This sets how much the ramp can change the VCO frequency before calibrating. If this frequency is chosen to be Δf, then it is calculated as follows: RAMP_THRESH = (Δf / fPD) × 16777216",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 81,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 0,
+                "start": 0,
+                "name": "RAMP_LIMIT_HIGH[32:32]",
+                "description": "This sets a maximum frequency that the ramp can not exceed so that the VCO does not get set beyond a valid frequency range. Suppose fHIGH is this frequency and fVCO is the starting VCO frequency then: For fHIGH ≥ fVCO: RAMP_LIMIT_HIGH = (fHIGH – fVCO)/fPD × 16777216 For fHIGH < fVCO this is not a valid condition to choose",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 82,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "RAMP_LIMIT_HIGH[31:16]",
+                "description": "This sets a maximum frequency that the ramp can not exceed so that the VCO does not get set beyond a valid frequency range. Suppose fHIGH is this frequency and fVCO is the starting VCO frequency then: For fHIGH ≥ fVCO: RAMP_LIMIT_HIGH = (fHIGH – fVCO)/fPD × 16777216 For fHIGH < fVCO this is not a valid condition to choose",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 83,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "RAMP_LIMIT_HIGH[15:0]",
+                "description": "This sets a maximum frequency that the ramp can not exceed so that the VCO does not get set beyond a valid frequency range. Suppose fHIGH is this frequency and fVCO is the starting VCO frequency then: For fHIGH ≥ fVCO: RAMP_LIMIT_HIGH = (fHIGH – fVCO)/fPD × 16777216 For fHIGH < fVCO this is not a valid condition to choose",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 84,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 0,
+                "start": 0,
+                "name": "RAMP_LIMIT_LOW[32:32]",
+                "description": "This sets a minimum frequency that the ramp can not exceed so that the VCO does not get set beyond a valid frequency range. Suppose fLOW is this frequency and fVCO is the starting VCO frequency then: For fLOW ≤ fVCO: RAMP_LIMIT_LOW = 2 33 – 16777216 x (fVCO – fLOW) / fPD For fLOW > fVCO, this is not a valid condition to choose.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 85,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "RAMP_LIMIT_LOW[31:16]",
+                "description": "This sets a minimum frequency that the ramp can not exceed so that the VCO does not get set beyond a valid frequency range. Suppose fLOW is this frequency and fVCO is the starting VCO frequency then: For fLOW ≤ fVCO: RAMP_LIMIT_LOW = 2 33 – 16777216 x (fVCO – fLOW) / fPD For fLOW > fVCO, this is not a valid condition to choose.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 86,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "RAMP_LIMIT_LOW[15:0]",
+                "description": "This sets a minimum frequency that the ramp can not exceed so that the VCO does not get set beyond a valid frequency range. Suppose fLOW is this frequency and fVCO is the starting VCO frequency then: For fLOW ≤ fVCO: RAMP_LIMIT_LOW = 2 33 – 16777216 x (fVCO – fLOW) / fPD For fLOW > fVCO, this is not a valid condition to choose.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 87,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 88,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 89,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 90,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 91,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 92,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 93,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 94,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 95,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 96,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 15,
+                "name": "RAMP_BURST_EN",
+                "description": "Enables burst ramping mode. In this mode, a RAMP_BURST_COUNT ramps are sent out when RAMP_EN is set from 0 to 1.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 14,
+                "start": 2,
+                "name": "RAMP_BURST_COUNT",
+                "description": "Sets how many ramps are run in burst ramping mode",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 97,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 15,
+                "name": "RAMP0_RST",
+                "description": "Resets RAMP0 at start of ramp to eliminate round-off errors. Must only be used in automatic ramping mode.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 10,
+                "start": 7,
+                "name": "RAMP_TRIGB",
+                "description": "Multipurpose trigger B definition",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "RAMP_CLK_RISING_EDGE",
+                            "description": "RampClk pin rising edge"
+                        },
+                        {
+                            "value": 2,
+                            "name": "RAMP_DIR_RISING_EDGE",
+                            "description": "RampDir pin rising edge"
+                        },
+                        {
+                            "value": 4,
+                            "name": "ALWAYS",
+                            "description": "Always triggered"
+                        },
+                        {
+                            "value": 9,
+                            "name": "RAMP_CLK_FALLING_EDGE",
+                            "description": "RampClk pin falling edge"
+                        },
+                        {
+                            "value": 10,
+                            "name": "RAMP_DIR_FALLING_EDGE",
+                            "description": "RampDir pin falling edge"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 6,
+                "start": 3,
+                "name": "RAMP_TRIGA",
+                "description": "Multipurpose Trigger A definition",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "RAMP_CLK_RISING_EDGE",
+                            "description": "RampClk pin rising edge"
+                        },
+                        {
+                            "value": 2,
+                            "name": "RAMP_DIR_RISING_EDGE",
+                            "description": "RampDir pin rising edge"
+                        },
+                        {
+                            "value": 4,
+                            "name": "ALWAYS",
+                            "description": "Always triggered"
+                        },
+                        {
+                            "value": 9,
+                            "name": "RAMP_CLK_FALLING_EDGE",
+                            "description": "RampClk pin falling edge"
+                        },
+                        {
+                            "value": 10,
+                            "name": "RAMP_DIR_FALLING_EDGE",
+                            "description": "RampDir pin falling edge"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 1,
+                "start": 0,
+                "name": "RAMP_BURST_TRIG",
+                "description": "Ramp burst trigger definition that triggers the next ramp in the count. Note that RAMP_EN starts the count, not this word.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "RAMP_TRANSITION",
+                            "description": "Ramp Transition"
+                        },
+                        {
+                            "value": 1,
+                            "name": "TRIGGER_A",
+                            "description": "Trigger A"
+                        },
+                        {
+                            "value": 2,
+                            "name": "TRIGGER_B",
+                            "description": "Trigger B"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 2048
+            }
+        ]
+    },
+    {
+        "addr": 98,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 2,
+                "name": "RAMP0_INC[29:16]",
+                "description": "2's complement of the amount the RAMP0 is incremented in phase detector cycles.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 0,
+                "start": 0,
+                "name": "RAMP0_DLY",
+                "description": "Enabling this bit uses two clocks instead of one to clock the ramp. Effectively doubling the length.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "NORMAL_LENGTH",
+                            "description": "Normal ramp length"
+                        },
+                        {
+                            "value": 1,
+                            "name": "DOUBLE_LENGTH",
+                            "description": "Double ramp length"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 99,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "RAMP0_INC[15:0]",
+                "description": "2's complement of the amount the RAMP0 is incremented in phase detector cycles.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 100,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "RAMP0_LEN",
+                "description": "Length of RAMP0 in phase detector cycles",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 101,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 6,
+                "start": 6,
+                "name": "RAMP1_DLY",
+                "description": "Enabling this bit uses two clocks instead of one to clock the ramp. Effectively doubling the length.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "NORMAL_LENGTH",
+                            "description": "Normal ramp length"
+                        },
+                        {
+                            "value": 1,
+                            "name": "DOUBLE_LENGTH",
+                            "description": "Double ramp length"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 5,
+                "start": 5,
+                "name": "RAMP1_RST",
+                "description": "Resets RAMP1 to eliminate rounding errors. Must be used in automatic ramping mode.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 4,
+                "start": 4,
+                "name": "RAMP0_NEXT",
+                "description": "Defines what ramp comes after RAMP0",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "RAMP0",
+                            "description": "Ramp 0"
+                        },
+                        {
+                            "value": 1,
+                            "name": "RAMP1",
+                            "description": "Ramp 1"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 1,
+                "start": 0,
+                "name": "RAMP0_NEXT_TRIG",
+                "description": "Defines what triggers the next ramp",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "TIMEOUT_COUNTER",
+                            "description": "RAMP0_LEN timeout counter"
+                        },
+                        {
+                            "value": 1,
+                            "name": "TRIGGER_A",
+                            "description": "Trigger A"
+                        },
+                        {
+                            "value": 2,
+                            "name": "TRIGGER_B",
+                            "description": "Trigger B"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 102,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 13,
+                "start": 0,
+                "name": "RAMP1_INC[29:16]",
+                "description": "2's complement of the amount the RAMP1 is incremented in phase detector cycles",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 103,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "RAMP1_INC[15:0]",
+                "description": "2's complement of the amount the RAMP1 is incremented in phase detector cycles",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 104,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 0,
+                "name": "RAMP1_LEN",
+                "description": "Length of RAMP1 in phase detector cycles",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 105,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 15,
+                "start": 6,
+                "name": "RAMP_DLY_CNT",
+                "description": "This is the number of state machine clock cycles for the VCO calibration in automatic mode. If the VCO calibration is less, then it is this time. If it is more, then the time is the VCO calibration time.",
+                "default": 0,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 5,
+                "start": 5,
+                "name": "RAMP_MANUAL",
+                "description": "Enables manual ramping mode, or otherwise automatic mode",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "AUTOMATIC",
+                            "description": "Automatic ramping mode"
+                        },
+                        {
+                            "value": 1,
+                            "name": "MANUAL",
+                            "description": "Manual ramping mode"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 4,
+                "start": 4,
+                "name": "RAMP1_NEXT",
+                "description": "Determines what ramp comes after RAMP1",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "RAMP0",
+                            "description": "Ramp 0"
+                        },
+                        {
+                            "value": 1,
+                            "name": "RAMP1",
+                            "description": "Ramp 1"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 1,
+                "start": 0,
+                "name": "RAMP1_NEXT_TRIG",
+                "description": "Defines what triggers the next ramp",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "RAMP1_LEN_TIMEOUT",
+                            "description": "RAMP1_LEN timeout counter"
+                        },
+                        {
+                            "value": 1,
+                            "name": "TRIGGER_A",
+                            "description": "Trigger A"
+                        },
+                        {
+                            "value": 2,
+                            "name": "TRIGGER_B",
+                            "description": "Trigger B"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 106,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 4,
+                "start": 4,
+                "name": "RAMP_TRIG_CAL",
+                "description": "Enabling this bit forces the VCO to calibrate after the ramp.",
+                "default": 0,
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "DISABLED",
+                            "description": "Disabled"
+                        },
+                        {
+                            "value": 1,
+                            "name": "ENABLED",
+                            "description": "Enabled"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 2,
+                "start": 0,
+                "name": "RAMP_SCALE_COUNT",
+                "description": "Multiplies RAMP_DLY count by 2^RAMP_SCALE_COUNT",
+                "default": 7,
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 107,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 108,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 109,
+        "fields": [
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 110,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 10,
+                "start": 9,
+                "name": "rb_LD_VTUNE",
+                "description": "Readback of Vtune lock detect",
+                "default": 0,
+                "access": "R",
+                "valid": {
+                    "type": "enum",
+                    "values": [
+                        {
+                            "value": 0,
+                            "name": "UNLOCKED_LOW",
+                            "description": "Unlocked (Vtune low)"
+                        },
+                        {
+                            "value": 1,
+                            "name": "INVALID_STATE",
+                            "description": "Invalid State"
+                        },
+                        {
+                            "value": 2,
+                            "name": "LOCKED",
+                            "description": "Locked"
+                        },
+                        {
+                            "value": 3,
+                            "name": "UNLOCKED_HIGH",
+                            "description": "Unlocked (Vtune High)"
+                        }
+                    ]
+                }
+            },
+            {
+                "fieldtype": "normal",
+                "end": 7,
+                "start": 5,
+                "name": "rb_VCO_SEL",
+                "description": "Reads back the actual VCO that the calibration has selected.",
+                "default": 0,
+                "access": "R",
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 111,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 7,
+                "start": 0,
+                "name": "rb_VCO_CAPCTRL",
+                "description": "Reads back the actual CAPCTRL capcode value the VCO calibration has chosen.",
+                "default": 183,
+                "access": "R",
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    },
+    {
+        "addr": 112,
+        "fields": [
+            {
+                "fieldtype": "normal",
+                "end": 8,
+                "start": 0,
+                "name": "rb_VCO_DACISET",
+                "description": "Reads back the actual amplitude (DACISET) value that the VCO calibration has chosen.",
+                "default": 170,
+                "access": "R",
+                "valid": {
+                    "type": "int"
+                }
+            },
+            {
+                "fieldtype": "constant",
+                "end": 15,
+                "start": 0,
+                "value": 0
+            }
+        ]
+    }
+]

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1253,29 +1253,18 @@ class MrBufferEt(SocIp):
         # Route switch to channel.
         self.switch.sel(slv=ch)
 
-    def capture(self):
-        self.dw_capture_reg = 1
-        time.sleep(1)
-        self.dw_capture_reg = 0
-
-    def transfer(self):
+    def transfer(self, buff=None):
+        if buff is None:
+            buff = self.buff
         # Start send data mode.
         self.dr_start_reg = 1
 
         # DMA data.
-        buff = self.buff
         self.dma.recvchannel.transfer(buff)
         self.dma.recvchannel.wait()
 
         # Stop send data mode.
         self.dr_start_reg = 0
-
-        # Format:
-        # -> lower 16 bits: I value.
-        # -> higher 16 bits: Q value.
-        data = buff
-        dataI = data & 0xFFFF
-        dataQ = data >> 16
 
         return buff
 

--- a/qick_lib/qick/rfboard.py
+++ b/qick_lib/qick/rfboard.py
@@ -1484,7 +1484,7 @@ class lo_synth_v2:
         #print(status.value_description)
         return status.value == self.lmx.rb_LD_VTUNE.LOCKED.value
 
-    def set_freq(self, f, pwr=31, osc_2x=False, reset=True, verbose=False):
+    def set_freq(self, f, pwr=50, osc_2x=False, reset=True, verbose=False):
         self.lmx.set_output_frequency(f, pwr=pwr, en_b=True, osc_2x=osc_2x, verbose=verbose)
         if reset: self.reset()
         self.program()
@@ -1584,7 +1584,7 @@ class RFQickSocV2(RFQickSoc):
                 tile, block = [int(a) for a in ro.adc]
                 ro.rfb = self.adcs[2*tile + block]
 
-    def rfb_set_lo(self, f, ch=None):
+    def rfb_set_lo(self, f, ch=None, verbose=False):
         """Set RF-board local oscillators.
 
         LO[0]: all RF ADCs
@@ -1597,12 +1597,14 @@ class RFQickSocV2(RFQickSoc):
             Frequency (4000-8000 MHz)
         ch : int
             LO to configure (None=all)
+        verbose : bool
+            Print freq and lock info.
         """
         if ch is not None:
-            self.lo[ch].set_freq(f)
+            self.lo[ch].set_freq(f, verbose=verbose)
         else:
             for lo in self.lo:
-                lo.set_freq(f)
+                lo.set_freq(f, verbose=verbose)
 
     def rfb_get_lo(self, gen_ch=None, ro_ch=None):
         """Get local oscillator frequency for a DAC or ADC channel.


### PR DESCRIPTION
* KIT-IPQ has developed a pretty sophisticated library for managing the register map of the LO chip we use on the V2 RF board. We are copying it (with license+attribution), with changes.
* Channels initialize to power-down state, and are enabled at configuration.
* The V1 RF board code has also been changed, since various common code has been tweaked. It should work identically, but that hasn't really been tested.
* Minor breaking change: rfb_set_genrf() is renamed to rfb_set_gen_rf(), rfb_set_ro() is renamed to rfb_set_ro_rf() - for consistency.