### PR TITLE
add message to declare_readout() that warns the user if their readout…

### DIFF
--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -1,6 +1,7 @@
 """
 The higher-level driver for the QICK library. Contains an tProc assembly language wrapper class and auxiliary functions.
 """
+import logging
 import numpy as np
 import json
 from collections import namedtuple, OrderedDict
@@ -14,6 +15,8 @@ try:
 except ModuleNotFoundError:
     def obtain(i):
         return i
+
+logger = logging.getLogger(__name__)
 
 class QickConfig():
     """Uses the QICK configuration to convert frequencies and clock delays.
@@ -1213,6 +1216,10 @@ class QickProgram:
         gen_ch : int
             DAC channel (use None if you don't want the downconversion frequency to be rounded to a valid DAC frequency or be offset by the DAC mixer frequency)
         """
+        # this number comes from the fact that the ADC is 12 bit + 3 bits from decimation = 15 bit
+        # and the sum buffer values are 32 bit signed
+        if length > 2**(31-15):
+            logger.warning(f'With the given readout length there is a possibility that the sum buffer will overflow giving invalid results.')
         cfg = {
                 'freq': freq,
                 'length': length,


### PR DESCRIPTION
… length will potentially overflow the sum buffer