### PR TITLE
Reference clock

### DIFF
--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -2081,7 +2081,7 @@ class QickSoc(Overlay, QickConfig):
         if self['board'] == 'ZCU111':
             print("resetting clocks:", self['refclk_freq'])
 
-            if hasattr(xrfclk, "xrfclk"):
+            if hasattr(xrfclk, "xrfclk"): # pynq 2.7
                 # load the default clock chip configurations from file, so we can then modify them
                 xrfclk.xrfclk._find_devices()
                 xrfclk.xrfclk._read_tics_output()
@@ -2089,7 +2089,7 @@ class QickSoc(Overlay, QickConfig):
                     # change the register for the LMK04208 chip's 5th output, which goes to J108
                     # we need this for driving the RF board
                     xrfclk.xrfclk._Config['lmk04208'][122.88][6] = 0x00140325
-            else:
+            else: # pynq 2.6
                 if self.ENABLE_LO_OUTPUT:
                     # change the register for the LMK04208 chip's 5th output, which goes to J108
                     # we need this for driving the RF board
@@ -2097,34 +2097,19 @@ class QickSoc(Overlay, QickConfig):
                 else:
                     # restore the default clock config
                     xrfclk._lmk04208Config[122.88][6] = 0x80141E05
-
             xrfclk.set_all_ref_clks(self['refclk_freq'])
         elif self['board'] == 'ZCU216':
             lmk_freq = self['refclk_freq']
             lmx_freq = self['refclk_freq']*2
-            if external_clk== False: 
-                print("resetting clocks:", lmk_freq, lmx_freq)
-                if hasattr(xrfclk, "xrfclk"):
-                    xrfclk.xrfclk._find_devices()
-                    xrfclk.xrfclk._read_tics_output()
-                    xrfclk.xrfclk._Config['lmk04828'][245.76][80] = 0x01471A
-                else:                   
-                    xrfclk._Config['lmk04828'][245.76][80] = 0x01471A
-                xrfclk.set_ref_clks(lmk_freq=lmk_freq, lmx_freq=lmx_freq)
-            else:
-                if hasattr(xrfclk, "xrfclk"):
-                    xrfclk.xrfclk._find_devices()
-                    xrfclk.xrfclk._read_tics_output()
-                    print("resetting clocks:", lmk_freq, lmx_freq)
-                    xrfclk.xrfclk._Config['lmk04828'][245.76][80] = 0x01470A
-                    xrfclk.set_ref_clks(lmk_freq=lmk_freq, lmx_freq=lmx_freq)
-                else:
-                    xrfclk._find_devices()
-                    xrfclk._read_tics_output()
-                    print("resetting clocks:", lmk_freq, lmx_freq)
-                    xrfclk._Config['lmk04828'][245.76][80] = 0x01470A
-                    xrfclk.set_ref_clks(lmk_freq=lmk_freq, lmx_freq=lmx_freq)
+            print("resetting clocks:", lmk_freq, lmx_freq)
 
+            assert hasattr(xrfclk, "xrfclk") # ZCU216 only has a pynq 2.7 image
+            xrfclk.xrfclk._find_devices()
+            xrfclk.xrfclk._read_tics_output()
+            if external_clk:
+                # default value is 0x01471A
+                xrfclk.xrfclk._Config['lmk04828'][245.76][80] = 0x01470A
+            xrfclk.set_ref_clks(lmk_freq=lmk_freq, lmx_freq=lmx_freq)
         elif self['board'] == 'RFSoC4x2':
             lmk_freq = self['refclk_freq']/2
             lmx_freq = self['refclk_freq']

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1762,7 +1762,7 @@ class QickSoc(Overlay, QickConfig):
     :type bitfile: str
     :param force_init_clks: Whether the board clocks are re-initialized
     :type force_init_clks: bool
-    :param external_clk: When set to true it will use the Input_Ref_CLK J11 port on the ZCU216 and expects an external 10 MHz clock
+    :param external_clk: When set to true it will use the Input_Ref_CLK J11 port on the ZCU216 and expects an external 10 MHz clock. Use force_init_clks=True to change to or from an external reference clock.
     :type external_clk: bool
     :param ignore_version: Whether version discrepancies between PYNQ build and firmware build are ignored
     :type ignore_version: bool

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1762,9 +1762,9 @@ class QickSoc(Overlay, QickConfig):
     :type bitfile: str
     :param force_init_clks: Re-initialize the board clocks regardless of whether they appear to be locked. Enabling the clk_output or external_clk options will also force clock initialization.
     :type force_init_clks: bool
-    :param clk_output: Output a copy of the RF refclk. This option is supported for the ZCU111 (use J108) and ZCU216 (use OUTPUT_REF J10).
+    :param clk_output: Output a copy of the RF reference. This option is supported for the ZCU111 (get 122.88 MHz from J108) and ZCU216 (get 245.76 MHz from OUTPUT_REF J10).
     :type clk_output: bool
-    :param external_clk: Lock the board clocks to an external 10 MHz reference. This option is supported for the ZCU216 (use INPUT_REF_CLK J11).
+    :param external_clk: Lock the board clocks to an external reference. This option is supported for the ZCU111 (put 12.8 MHz on External_REF_CLK J109) and ZCU216 (put 10 MHz on INPUT_REF_CLK J11).
     :type external_clk: bool
     :param ignore_version: Whether version discrepancies between PYNQ build and firmware build are ignored
     :type ignore_version: bool
@@ -2093,6 +2093,9 @@ class QickSoc(Overlay, QickConfig):
                     # change the register for the LMK04208 chip's 5th output, which goes to J108
                     # we need this for driving the RF board
                     xrfclk.xrfclk._Config['lmk04208'][122.88][6] = 0x00140325
+                if self.external_clk:
+                    # default value is 0x2302886D
+                    xrfclk.xrfclk._Config['lmk04208'][122.88][14] = 0x2302826D
             else: # pynq 2.6
                 if self.clk_output:
                     # change the register for the LMK04208 chip's 5th output, which goes to J108
@@ -2101,6 +2104,10 @@ class QickSoc(Overlay, QickConfig):
                 else:
                     # restore the default clock config
                     xrfclk._lmk04208Config[122.88][6] = 0x80141E05
+                if self.external_clk:
+                    xrfclk._lmk04208Config[122.88][14] = 0x2302826D
+                else:
+                    xrfclk._lmk04208Config[122.88][14] = 0x2302886D
             xrfclk.set_all_ref_clks(self['refclk_freq'])
         elif self['board'] == 'ZCU216':
             lmk_freq = self['refclk_freq']

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1764,7 +1764,7 @@ class QickSoc(Overlay, QickConfig):
     :type force_init_clks: bool
     :param clk_output: Output a copy of the RF reference. This option is supported for the ZCU111 (get 122.88 MHz from J108) and ZCU216 (get 245.76 MHz from OUTPUT_REF J10).
     :type clk_output: bool
-    :param external_clk: Lock the board clocks to an external reference. This option is supported for the ZCU111 (put 12.8 MHz on External_REF_CLK J109) and ZCU216 (put 10 MHz on INPUT_REF_CLK J11).
+    :param external_clk: Lock the board clocks to an external reference. This option is supported for the ZCU111 (put 12.8 MHz on External_REF_CLK J109), ZCU216 (put 10 MHz on INPUT_REF_CLK J11), and RFSoC 4x2 (put 10 MHz on CLK_IN).
     :type external_clk: bool
     :param ignore_version: Whether version discrepancies between PYNQ build and firmware build are ignored
     :type ignore_version: bool
@@ -2128,6 +2128,12 @@ class QickSoc(Overlay, QickConfig):
             lmk_freq = self['refclk_freq']/2
             lmx_freq = self['refclk_freq']
             print("resetting clocks:", lmk_freq, lmx_freq)
+            xrfclk.xrfclk._find_devices()
+            xrfclk.xrfclk._read_tics_output()
+            print(xrfclk.xrfclk._Config['lmk04828'][245.76][80])
+            if self.external_clk:
+                # default value is 0x01471A
+                xrfclk.xrfclk._Config['lmk04828'][245.76][80] = 0x01470A
             xrfclk.set_ref_clks(lmk_freq=lmk_freq, lmx_freq=lmx_freq)
 
     def get_decimated(self, ch, address=0, length=None):

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1762,6 +1762,8 @@ class QickSoc(Overlay, QickConfig):
     :type bitfile: str
     :param force_init_clks: Whether the board clocks are re-initialized
     :type force_init_clks: bool
+    :param external_clk: When set to true it will use the Input_Ref_CLK J11 port on the ZCU216 and expects an external 10 MHz clock
+    :type external_clk: bool
     :param ignore_version: Whether version discrepancies between PYNQ build and firmware build are ignored
     :type ignore_version: bool
     """
@@ -1787,7 +1789,7 @@ class QickSoc(Overlay, QickConfig):
     #gain_resolution_signed_bits = 16
 
     # Constructor.
-    def __init__(self, bitfile=None, force_init_clks=False, ignore_version=True, no_tproc=False, external_clock=False, **kwargs):
+    def __init__(self, bitfile=None, force_init_clks=False, ignore_version=True, no_tproc=False, external_clk=False, **kwargs):
         """
         Constructor method
         """
@@ -1810,7 +1812,7 @@ class QickSoc(Overlay, QickConfig):
         self.list_rf_blocks(
             self.ip_dict['usp_rf_data_converter_0']['parameters'])
 
-        self.config_clocks(force_init_clks, external_clock)
+        self.config_clocks(force_init_clks, external_clk)
 
         # RF data converter (for configuring ADCs and DACs, and setting NCOs)
         self.rf = self.usp_rf_data_converter_0
@@ -1978,17 +1980,17 @@ class QickSoc(Overlay, QickConfig):
             thiscfg['dmem_size'] = 2**tproc.DMEM_N
             self['tprocs'].append(thiscfg)
 
-    def config_clocks(self, force_init_clks, external_clock):
+    def config_clocks(self, force_init_clks, external_clk):
         """
         Configure PLLs if requested, or if any ADC/DAC is not locked.
         """
         if force_init_clks:
-            self.set_all_clks(external_clock)
+            self.set_all_clks(external_clk)
             self.download()
         else:
             self.download()
             if not self.clocks_locked():
-                self.set_all_clks(external_clock)
+                self.set_all_clks(external_clk)
                 self.download()
         if not self.clocks_locked():
             print(
@@ -2072,7 +2074,7 @@ class QickSoc(Overlay, QickConfig):
 
         self['refclk_freq'] = get_common_freq(refclk_freqs)
 
-    def set_all_clks(self, external_clock):
+    def set_all_clks(self, external_clk):
         """
         Resets all the board clocks
         """
@@ -2100,7 +2102,7 @@ class QickSoc(Overlay, QickConfig):
         elif self['board'] == 'ZCU216':
             lmk_freq = self['refclk_freq']
             lmx_freq = self['refclk_freq']*2
-            if external_clock== False: 
+            if external_clk== False: 
                 print("resetting clocks:", lmk_freq, lmx_freq)
                 if hasattr(xrfclk, "xrfclk"):
                     xrfclk.xrfclk._find_devices()

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1787,7 +1787,7 @@ class QickSoc(Overlay, QickConfig):
     #gain_resolution_signed_bits = 16
 
     # Constructor.
-    def __init__(self, bitfile=None, force_init_clks=False, ignore_version=True, no_tproc=False, **kwargs):
+    def __init__(self, bitfile=None, force_init_clks=False, ignore_version=True, no_tproc=False, external_clock=False, **kwargs):
         """
         Constructor method
         """
@@ -1810,7 +1810,7 @@ class QickSoc(Overlay, QickConfig):
         self.list_rf_blocks(
             self.ip_dict['usp_rf_data_converter_0']['parameters'])
 
-        self.config_clocks(force_init_clks)
+        self.config_clocks(force_init_clks, external_clock)
 
         # RF data converter (for configuring ADCs and DACs, and setting NCOs)
         self.rf = self.usp_rf_data_converter_0
@@ -1978,17 +1978,17 @@ class QickSoc(Overlay, QickConfig):
             thiscfg['dmem_size'] = 2**tproc.DMEM_N
             self['tprocs'].append(thiscfg)
 
-    def config_clocks(self, force_init_clks):
+    def config_clocks(self, force_init_clks, external_clock):
         """
         Configure PLLs if requested, or if any ADC/DAC is not locked.
         """
         if force_init_clks:
-            self.set_all_clks()
+            self.set_all_clks(external_clock)
             self.download()
         else:
             self.download()
             if not self.clocks_locked():
-                self.set_all_clks()
+                self.set_all_clks(external_clock)
                 self.download()
         if not self.clocks_locked():
             print(
@@ -2072,7 +2072,7 @@ class QickSoc(Overlay, QickConfig):
 
         self['refclk_freq'] = get_common_freq(refclk_freqs)
 
-    def set_all_clks(self):
+    def set_all_clks(self, external_clock):
         """
         Resets all the board clocks
         """
@@ -2100,8 +2100,29 @@ class QickSoc(Overlay, QickConfig):
         elif self['board'] == 'ZCU216':
             lmk_freq = self['refclk_freq']
             lmx_freq = self['refclk_freq']*2
-            print("resetting clocks:", lmk_freq, lmx_freq)
-            xrfclk.set_ref_clks(lmk_freq=lmk_freq, lmx_freq=lmx_freq)
+            if external_clock== False: 
+                print("resetting clocks:", lmk_freq, lmx_freq)
+                if hasattr(xrfclk, "xrfclk"):
+                    xrfclk.xrfclk._find_devices()
+                    xrfclk.xrfclk._read_tics_output()
+                    xrfclk.xrfclk._Config['lmk04828'][245.76][80] = 0x01471A
+                else:                   
+                    xrfclk._Config['lmk04828'][245.76][80] = 0x01471A
+                xrfclk.set_ref_clks(lmk_freq=lmk_freq, lmx_freq=lmx_freq)
+            else:
+                if hasattr(xrfclk, "xrfclk"):
+                    xrfclk.xrfclk._find_devices()
+                    xrfclk.xrfclk._read_tics_output()
+                    print("resetting clocks:", lmk_freq, lmx_freq)
+                    xrfclk.xrfclk._Config['lmk04828'][245.76][80] = 0x01470A
+                    xrfclk.set_ref_clks(lmk_freq=lmk_freq, lmx_freq=lmx_freq)
+                else:
+                    xrfclk._find_devices()
+                    xrfclk._read_tics_output()
+                    print("resetting clocks:", lmk_freq, lmx_freq)
+                    xrfclk._Config['lmk04828'][245.76][80] = 0x01470A
+                    xrfclk.set_ref_clks(lmk_freq=lmk_freq, lmx_freq=lmx_freq)
+
         elif self['board'] == 'RFSoC4x2':
             lmk_freq = self['refclk_freq']/2
             lmx_freq = self['refclk_freq']

--- a/qick_lib/qick/rfboard.py
+++ b/qick_lib/qick/rfboard.py
@@ -1304,15 +1304,13 @@ class RFQickSoc(QickSoc):
     Overrides the __init__ method of QickSoc in order to add the drivers for the preproduction (V1) version of the RF board.
     Otherwise supports all the QickSoc functionality.
     """
-    ENABLE_LO_OUTPUT = True
-
-    def __init__(self, bitfile, force_init_clks=True, ignore_version=True, no_tproc=False, **kwargs):
+    def __init__(self, bitfile, **kwargs):
         """
         A bitfile must always be provided, since the default bitstream will not work with the RF board.
         By default, re-initialize the clocks every time.
         This ensures that the LO output to the RF board is enabled.
         """
-        super().__init__(bitfile=bitfile, force_init_clks=force_init_clks, ignore_version=ignore_version, no_tproc=no_tproc, **kwargs)
+        super().__init__(bitfile=bitfile, clk_output=True, **kwargs)
 
         self.rfb_config(no_tproc)
 


### PR DESCRIPTION
With the parameter external_reference = True when initializing the QickSoC class the INPUT_REF_CLK J11 port on the ZCU216 board will be used. The external reference clock needs to be 10 MHz. To change it after initialization the parameter force_init_clks = True is required.