### PR TITLE
bug fix from external_clk = True to external_clk = False

### DIFF
--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1760,12 +1760,12 @@ class QickSoc(Overlay, QickConfig):
 
     :param bitfile: Name of the bitfile
     :type bitfile: str
-    :param force_init_clks: Re-initialize the board clocks regardless of whether they appear to be locked. Enabling the clk_output or external_clk options will also force clock initialization.
+    :param force_init_clks: Re-initialize the board clocks regardless of whether they appear to be locked. Specifying (as True or False) the clk_output or external_clk options will also force clock initialization.
     :type force_init_clks: bool
-    :param clk_output: Output a copy of the RF reference. This option is supported for the ZCU111 (get 122.88 MHz from J108) and ZCU216 (get 245.76 MHz from OUTPUT_REF J10).
-    :type clk_output: bool
-    :param external_clk: Lock the board clocks to an external reference. This option is supported for the ZCU111 (put 12.8 MHz on External_REF_CLK J109), ZCU216 (put 10 MHz on INPUT_REF_CLK J11), and RFSoC 4x2 (put 10 MHz on CLK_IN).
-    :type external_clk: bool
+    :param clk_output: If true, output a copy of the RF reference. This option is supported for the ZCU111 (get 122.88 MHz from J108) and ZCU216 (get 245.76 MHz from OUTPUT_REF J10).
+    :type clk_output: bool or None
+    :param external_clk: If true, lock the board clocks to an external reference. This option is supported for the ZCU111 (put 12.8 MHz on External_REF_CLK J109), ZCU216 (put 10 MHz on INPUT_REF_CLK J11), and RFSoC 4x2 (put 10 MHz on CLK_IN).
+    :type external_clk: bool or None
     :param ignore_version: Whether version discrepancies between PYNQ build and firmware build are ignored
     :type ignore_version: bool
     """
@@ -1988,13 +1988,13 @@ class QickSoc(Overlay, QickConfig):
         Configure PLLs if requested, or if any ADC/DAC is not locked.
         """
               
-        # if we're using any nonstandard clock configuration, we must set the clocks to apply the config
-        if force_init_clks or (self.external_clk!=None) or (self.clk_output!= None):
+        # if we're changing the clock config, we must set the clocks to apply the config
+        if force_init_clks or (self.external_clk is not None) or (self.clk_output is not None):
             self.set_all_clks()
             self.download()
         else:
             self.download()
-            if not self.clocks_locked() or clock_initialized:
+            if not self.clocks_locked():
                 self.set_all_clks()
                 self.download()
         if not self.clocks_locked():
@@ -2102,12 +2102,11 @@ class QickSoc(Overlay, QickConfig):
                     # change the register for the LMK04208 chip's 5th output, which goes to J108
                     # we need this for driving the RF board
                     xrfclk._lmk04208Config[122.88][6] = 0x00140325
-                else:
-                    # restore the default clock config
+                else: # restore the default
                     xrfclk._lmk04208Config[122.88][6] = 0x80141E05
                 if self.external_clk:
                     xrfclk._lmk04208Config[122.88][14] = 0x2302826D
-                else:
+                else: # restore the default
                     xrfclk._lmk04208Config[122.88][14] = 0x2302886D
             xrfclk.set_all_ref_clks(self['refclk_freq'])
         elif self['board'] == 'ZCU216':

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1789,7 +1789,7 @@ class QickSoc(Overlay, QickConfig):
     #gain_resolution_signed_bits = 16
 
     # Constructor.
-    def __init__(self, bitfile=None, force_init_clks=False, ignore_version=True, no_tproc=False, clk_output=False, external_clk=None, **kwargs):
+    def __init__(self, bitfile=None, force_init_clks=False, ignore_version=True, no_tproc=False, clk_output=None, external_clk=None, **kwargs):
         """
         Constructor method
         """
@@ -1989,7 +1989,7 @@ class QickSoc(Overlay, QickConfig):
         """
               
         # if we're using any nonstandard clock configuration, we must set the clocks to apply the config
-        if force_init_clks or (self.external_clk!=None) or self.clk_output:
+        if force_init_clks or (self.external_clk!=None) or (self.clk_output!= None):
             self.set_all_clks()
             self.download()
         else:

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1789,7 +1789,7 @@ class QickSoc(Overlay, QickConfig):
     #gain_resolution_signed_bits = 16
 
     # Constructor.
-    def __init__(self, bitfile=None, force_init_clks=False, ignore_version=True, no_tproc=False, clk_output=False, external_clk=False, **kwargs):
+    def __init__(self, bitfile=None, force_init_clks=False, ignore_version=True, no_tproc=False, clk_output=False, external_clk=None, **kwargs):
         """
         Constructor method
         """
@@ -1987,19 +1987,9 @@ class QickSoc(Overlay, QickConfig):
         """
         Configure PLLs if requested, or if any ADC/DAC is not locked.
         """
-        try:
-            if self['board'] == 'ZCU111':
-                if hasattr(xrfclk, "xrfclk"): # pynq 2.7
-                    clock_initialized = (xrfclk.xrfclk._Config['lmk04208'][122.88][14] == 0x2302826D)
-                else: # pynq 2.6
-                    clock_initialized = xrfclk._lmk04208Config[122.88][14] = 0x2302826D
-            elif self['board'] == 'ZCU216' or self['board'] == 'RFSoC4x2': # both boards only have pynq 2.7
-                clock_initialized = (xrfclk.xrfclk._Config['lmk04828'][245.76][80] == 0x01470A) 
-        except KeyError:
-            clock_initialized = False
               
         # if we're using any nonstandard clock configuration, we must set the clocks to apply the config
-        if force_init_clks or self.external_clk or self.clk_output:
+        if force_init_clks or (self.external_clk!=None) or self.clk_output:
             self.set_all_clks()
             self.download()
         else:

--- a/qick_lib/qick/rfboard.py
+++ b/qick_lib/qick/rfboard.py
@@ -1304,13 +1304,13 @@ class RFQickSoc(QickSoc):
     Overrides the __init__ method of QickSoc in order to add the drivers for the preproduction (V1) version of the RF board.
     Otherwise supports all the QickSoc functionality.
     """
-    def __init__(self, bitfile, **kwargs):
+    def __init__(self, bitfile, no_tproc=False, **kwargs):
         """
         A bitfile must always be provided, since the default bitstream will not work with the RF board.
         By default, re-initialize the clocks every time.
         This ensures that the LO output to the RF board is enabled.
         """
-        super().__init__(bitfile=bitfile, clk_output=True, **kwargs)
+        super().__init__(bitfile=bitfile, clk_output=True, no_tproc=no_tproc, **kwargs)
 
         self.rfb_config(no_tproc)
 


### PR DESCRIPTION
When reloading the QickSoC with an external_clk=False the setting did not change because the if condition was not fulfilled. Now it checks whether the clocks have previously been set to an external_clk or not.