### PR TITLE
added a reset_phase function to QickProgram

### DIFF
--- a/qick_lib/qick/helpers.py
+++ b/qick_lib/qick/helpers.py
@@ -1,6 +1,7 @@
 """
 Support functions.
 """
+from typing import Union, List
 import numpy as np
 import json
 import base64
@@ -183,3 +184,19 @@ class BusParser:
                     self.nets[busname] |= set([port])
                 else:
                     self.nets[busname] = set([port])
+
+
+def ch2list(ch: Union[List[int], int]) -> List[int]:
+    """
+    convert a channel number or a list of ch numbers to list of integers
+
+    :param ch: channel number or list of channel numbers
+    :return: list of channel number(s)
+    """
+    if ch is None:
+        return []
+    try:
+        ch_list = [int(ch)]
+    except TypeError:
+        ch_list = ch
+    return ch_list


### PR DESCRIPTION
The recent new firmware supports resetting phases of multiple generator (and tproc-controlled readout) channels at the same time, and ensures stable relative phase between channels after each simultaneous reset. However, if two channels are reset at different tproc times, the relative phase between them is not guaranteed to be a constant from run to run (since the tproc and the DACs uses different clocks). 

So currently the good way to use this phase reset feature is to reset all the generator (and tproc-controlled readout) phases at the beginning of each experiment sequence (at the exact same time), and never reset it again until the end of the sequence.

To do this, this `reset_phase()` function could be handy.