### PR TITLE
PYNQ 3.0 is now supported

### DIFF
--- a/qick_lib/qick/helpers.py
+++ b/qick_lib/qick/helpers.py
@@ -121,49 +121,82 @@ def json2progs(s):
                 pulse['data'] = np.frombuffer(base64.b64decode(data), dtype=np.dtype(dtype)).reshape(shape)
     return proglist
 
-
-def trace_net(parser, blockname, portname):
+class QickMetadata:
     """
-    Find the block and port that connect to this block and port.
-    If you expect to only get one block+port as a result, you can assign the result to ((block, port),)
-
-    :param parser: HWH parser object (from Overlay.parser, or BusParser)
-    :param blockname: the IP block of interest
-    :type blockname: string
-    :param portname: the port we want to trace
-    :type portname: string
-
-    :return: a list of (block, port) pairs
-    :rtype: list
+    Provides information about the connections between IP blocks, extracted from the HWH file.
+    The HWH parser is very different between PYNQ 2.6/2.7 and 3.0+, so this class serves as a common interface.
     """
+    def __init__(self, soc):
+        # We will use the HWH parser to extract information about signal connections between blocks.
+        self.sigparser = None
+        self.busparser = None
+        self.systemgraph = None
 
-    fullport = blockname+"/"+portname
-    # the net connected to this port
-    netname = parser.pins[fullport]
-    if netname == '__NOC__':
-        return []
-    # get the list of other ports on this net, discard the port we started at and ILA ports
-    return [x.split('/') for x in parser.nets[netname] if x != fullport and 'system_ila_' not in x]
+        if hasattr(soc, 'systemgraph'):
+            # PYNQ 3.0 and higher have a "system graph"
+            self.systemgraph = soc.systemgraph
+        else:
+            self.sigparser = soc.parser
+            # Since the HWH parser doesn't parse buses, we also make our own BusParser.
+            self.busparser = BusParser(self.sigparser)
 
+    def trace_sig(self, blockname, portname):
+        return self._trace_net(self.sigparser, blockname, portname)
 
-def get_fclk(parser, blockname, portname):
-    """
-    Find the frequency of a clock port.
+    def trace_bus(self, blockname, portname):
+        return self._trace_net(self.busparser, blockname, portname)
 
-    :param parser: HWH parser object (from Overlay.parser, or BusParser)
-    :param blockname: the IP block of interest
-    :type blockname: string
-    :param portname: the port we want to trace
-    :type portname: string
+    def _trace_net(self, parser, blockname, portname):
+        """
+        Find the block and port that connect to this block and port.
+        If you expect to only get one block+port as a result, you can assign the result to ((block, port),)
 
-    :return: frequency in MHz
-    :rtype: float
-    """
-    xmlpath = "./MODULES/MODULE[@FULLNAME='/{0}']/PORTS/PORT[@NAME='{1}']".format(
-        blockname, portname)
-    port = parser.root.find(xmlpath)
-    return float(port.get('CLKFREQUENCY'))/1e6
+        :param parser: HWH parser object (from Overlay.parser, or BusParser)
+        :param blockname: the IP block of interest
+        :type blockname: string
+        :param portname: the port we want to trace
+        :type portname: string
 
+        :return: a list of (block, port) pairs
+        :rtype: list
+        """
+        if self.systemgraph is not None:
+            dests = self.systemgraph.blocks[blockname].ports[portname].destinations().items()
+            return [(block.parent().name, port) for port,block in dests]
+
+        fullport = blockname+"/"+portname
+        # the net connected to this port
+        netname = parser.pins[fullport]
+        if netname == '__NOC__':
+            return []
+        # get the list of other ports on this net, discard the port we started at and ILA ports
+        return [x.split('/') for x in parser.nets[netname] if x != fullport and 'system_ila_' not in x]
+
+    def get_fclk(self, blockname, portname):
+        """
+        Find the frequency of a clock port.
+
+        :param parser: HWH parser object (from Overlay.parser, or BusParser)
+        :param blockname: the IP block of interest
+        :type blockname: string
+        :param portname: the port we want to trace
+        :type portname: string
+
+        :return: frequency in MHz
+        :rtype: float
+        """
+        xmlpath = "./MODULES/MODULE[@FULLNAME='/{0}']/PORTS/PORT[@NAME='{1}']".format(
+            blockname, portname)
+        if self.systemgraph is not None:
+            port = self.systemgraph._element_tree.find(xmlpath)
+        else:
+            port = self.sigparser.root.find(xmlpath)
+        return float(port.get('CLKFREQUENCY'))/1e6
+
+    def mod2type(self, blockname):
+        if self.systemgraph is not None:
+            return self.systemgraph.blocks[blockname].vlnv.name
+        return self.busparser.mod2type[blockname]
 
 class BusParser:
     def __init__(self, parser):

--- a/qick_lib/qick/helpers.py
+++ b/qick_lib/qick/helpers.py
@@ -157,12 +157,19 @@ class QickMetadata:
         :param portname: the port we want to trace
         :type portname: string
 
-        :return: a list of (block, port) pairs
+        :return: a list of [block, port] pairs, or just [port] for ports of the top-level design
         :rtype: list
         """
         if self.systemgraph is not None:
-            dests = self.systemgraph.blocks[blockname].ports[portname].destinations().items()
-            return [(block.parent().name, port) for port,block in dests]
+            dests = self.systemgraph.blocks[blockname].ports[portname].destinations()
+            result = []
+            for port, block in dests.items():
+                blockname = block.parent().name
+                if blockname==self.systemgraph.name:
+                    result.append([port])
+                else:
+                    result.append([blockname, port])
+            return result
 
         fullport = blockname+"/"+portname
         # the net connected to this port

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1806,9 +1806,6 @@ class QickSoc(Overlay, QickConfig):
             Overlay.__init__(
                 self, bitfile, ignore_version=ignore_version, download=False, **kwargs)
 
-        # Extract the IP connectivity information from the HWH parser and metadata.
-        self.metadata = QickMetadata(self)
-
         # Initialize the configuration
         self._cfg = {}
         QickConfig.__init__(self)
@@ -1824,6 +1821,9 @@ class QickSoc(Overlay, QickConfig):
         # RF data converter (for configuring ADCs and DACs, and setting NCOs)
         self.rf = self.usp_rf_data_converter_0
         self.rf.configure(self)
+
+        # Extract the IP connectivity information from the HWH parser and metadata.
+        self.metadata = QickMetadata(self)
 
         if not no_tproc:
             # tProcessor, 64-bit instruction, 32-bit registers, x8 channels.

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1435,7 +1435,9 @@ class AxisTProc64x32_x8(SocIp):
         self.start_pin = None
         try:
             ((port),) = soc.metadata.trace_sig(self.fullpath, 'start')
-            self.start_pin = port[0]
+            # check if the start pin is driven by a port of the top-level design
+            if len(port)==1:
+                self.start_pin = port[0]
         except:
             pass
         # search for the trigger port

--- a/qick_lib/qick/qick.py
+++ b/qick_lib/qick/qick.py
@@ -1645,7 +1645,8 @@ class RFDC(xrfdc.RFdc):
     Since operations on the RFdc tend to be slow (tens of ms), we cache the Nyquist zone and frequency.
     """
     bindto = ["xilinx.com:ip:usp_rf_data_converter:2.3",
-              "xilinx.com:ip:usp_rf_data_converter:2.4"]
+              "xilinx.com:ip:usp_rf_data_converter:2.4",
+              "xilinx.com:ip:usp_rf_data_converter:2.6"]
 
     def __init__(self, description):
         """


### PR DESCRIPTION
PYNQ 3.0 introduced a new interface (https://github.com/Xilinx/PYNQ-Metadata) for getting firmware parameters out of the HWH file. This is much nicer than the old interface, but breaks many of the hacks we had devised for the old interface. As of this PR, there is now a common wrapper that works with both the old and new interfaces.

I haven't done much testing, but this appears to be the case:

* QICK firmware compiled with Vivado 2020.2 (the PYNQ 2.7 version, which we have been using for all firmware) will work on PYNQ 2.6-3.0.
* QICK firmware compiled with Vivado 2022.1 (the PYNQ 3.0 version) works on PYNQ 2.7 and 3.0. I haven't tried on 2.6 but it is probably OK.