### PR TITLE
Drop setup requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,8 +150,8 @@ setup(
     #
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    setup_requires=["numpy","cffi"],
-    
+    # setup_requires=["numpy","cffi"],
+
     # Only install pynq on the supported architectures.
     # If you're not installing this on a Zynq, you won't be able to use qick.py (hardware interface)
     # but qick_asm.py, averager_program.py, and the notebooks should still work.


### PR DESCRIPTION
The package is a pure Python one, without any special asset. So it does not actually have a build process, other than collecting files in a tarball/zip archive.

In particular, a wheel is just a special kind of zip archive, containing some metadata, and, for pure Python ones, just the source in certain locations.
For this reason, the wheel construction process seems to depend only on `setuptools` and `wheel`.
Source distributions only require making a tarball, by definition[*].

However, the `cffi` requirement breaks the installation from Git on MacOS, for a reason that is still obscure to me.
https://github.com/qiboteam/qibolab/pull/321#discussion_r1144477425

Since they are not used, and potentially harmful, I just propose to drop `setup_requires` dependencies.
Runtime dependencies are independent and still listed in `install_requires`.

[*]: possibly together with the same optional manipulations you would for a wheel, e.g. automatically retrieving the version and also writing it in files; but only the first part is done here, and does not require any further dependency  