### PR TITLE
support for DDR4 buffer

### DIFF
--- a/qick_lib/qick/drivers/readout.py
+++ b/qick_lib/qick/drivers/readout.py
@@ -797,6 +797,12 @@ class MrBufferEt(SocIp):
 
 
 class AxisBufferDdrV1(SocIp):
+    """
+    The DDR4 buffer block is similar to the decimated buffer in the avg_buffer block, except that data is written to DDR4 memory instead of FPGA memory.
+
+    Typically multiple readouts will be connected to this buffer through a switch.
+    The driver assumes that input(s) to this buffer are also sent to avg_buffer blocks.
+    """
     # AXIS Buffer DDR V1 Registers.
     bindto = ['user.org:user:axis_buffer_ddr_v1:1.0']
     REGISTERS = {   'rstart_reg' : 0,
@@ -833,12 +839,11 @@ class AxisBufferDdrV1(SocIp):
         self.DATA_WIDTH               = int(description['parameters']['DATA_WIDTH'])
         self.BURST_SIZE               = int(description['parameters']['BURST_SIZE']) + 1
 
+        self.cfg['burst_len'] = self.DATA_WIDTH*self.BURST_SIZE//32
+        self.cfg['readouts'] = []
+
     def configure_connections(self, soc):
         self.soc = soc
-
-        ##################################################
-        ### Backward tracing: should finish at the ADC ###
-        ##################################################
 
         # Typical: buffer_ddr -> clock_converter -> dwidth_converter -> switch (optional) -> broadcaster
         # the broadcaster will feed this block and a regular avg_buf
@@ -880,11 +885,27 @@ class AxisBufferDdrV1(SocIp):
                             if outname != port:
                                 ((bufname, _),) = soc.metadata.trace_bus(block, outname)
                                 self.buf2switch[bufname] = iIn
+                                self.cfg['readouts'].append(bufname)
                     else:
                         raise RuntimeError("tracing inputs to DDR4 switch and found something other than a broadcaster")
                 break
             else:
                 raise RuntimeError("falied to trace port for %s - unrecognized IP block %s" % (self.fullpath, block))
+
+        # which tProc output bit triggers this buffer?
+        ((block, port),) = soc.metadata.trace_sig(self.fullpath, 'trigger')
+        # vect2bits/qick_vec2bit port names are of the form 'dout14'
+        self.cfg['trigger_bit'] = int(port[4:])
+
+        # which tProc output port triggers this buffer?
+        # two possibilities:
+        # tproc v1 output port -> axis_set_reg -> vect2bits -> buffer
+        # tproc v2 data port -> vect2bits -> buffer
+        ((block, port),) = soc.metadata.trace_sig(block, 'din')
+        if soc.metadata.mod2type(block) == "axis_set_reg":
+            ((block, port),) = soc.metadata.trace_bus(block, 's_axis')
+        # ask the tproc to translate this port name to a channel number
+        self.cfg['trigger_port'], self.cfg['trigger_type'] = getattr(soc, block).port2ch(port)
 
     def rstop(self):
         self.rstart_reg = 0

--- a/qick_lib/qick/qick_asm.py
+++ b/qick_lib/qick/qick_asm.py
@@ -129,6 +129,9 @@ class QickConfig():
                 (tproc['type'], tproc['pmem_size'], tproc['dmem_size']))
         lines.append("\t\texternal start pin: %s" % (tproc['start_pin']))
 
+        if "ddr4_size" in self._cfg:
+            lines.append("\n\tDDR4 memory buffer: %d IQ pairs" % (self['ddr4_size']))
+
         return "\nQICK configuration:\n"+"\n".join(lines)
 
     def get_cfg(self):


### PR DESCRIPTION
This adds support for a buffer, similar to the decimated buffer, that writes to the onboard DDR4 memory instead of internal FPGA memory. This buffer can hold a billion IQ samples (a few seconds of data) and can be used in parallel with the regular readout (so you can run a long program with many accumulated shots, but also examine the decimated trace for debugging purposes).

The firmware block itself is still in testing.